### PR TITLE
update Get methods to return model instead of passing in pointer

### DIFF
--- a/exports/exports.go
+++ b/exports/exports.go
@@ -233,8 +233,8 @@ func (e *Export) getExportWithUser(w http.ResponseWriter, r *http.Request) *mode
 
 	user := middleware.GetUserIdentity(r.Context())
 
-	result := &models.ExportPayload{}
-	if err := e.DB.GetWithUser(exportUUID, user, result); err != nil {
+	result, err := e.DB.GetWithUser(exportUUID, user)
+	if err != nil {
 		switch err {
 		case models.ErrRecordNotFound:
 			e.Log.Infof("record '%s' not found", exportUUID)

--- a/exports/internal.go
+++ b/exports/internal.go
@@ -58,8 +58,8 @@ func (i *Internal) PostError(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	payload := &models.ExportPayload{}
-	if err := i.DB.Get(params.ExportUUID, payload); err != nil {
+	payload, err := i.DB.Get(params.ExportUUID)
+	if err != nil {
 		switch err {
 		case models.ErrRecordNotFound:
 			errors.NotFoundError(w, fmt.Sprintf("record '%s' not found", params.ExportUUID))
@@ -111,8 +111,8 @@ func (i *Internal) PostUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	payload := &models.ExportPayload{}
-	if err := i.DB.Get(params.ExportUUID, payload); err != nil {
+	payload, err := i.DB.Get(params.ExportUUID)
+	if err != nil {
 		switch err {
 		case models.ErrRecordNotFound:
 			errors.NotFoundError(w, fmt.Sprintf("record '%s' not found", params.ExportUUID))
@@ -207,8 +207,7 @@ func (i *Internal) compressPayload(payload *models.ExportPayload) {
 }
 
 func (i *Internal) processSources(uid uuid.UUID) {
-	var payload models.ExportPayload
-	err := i.DB.Get(uid, &payload)
+	payload, err := i.DB.Get(uid)
 	if err != nil {
 		i.Log.Errorf("failed to get payload: %v", err)
 		return
@@ -222,7 +221,7 @@ func (i *Internal) processSources(uid uuid.UUID) {
 	case models.StatusComplete, models.StatusPartial:
 		if payload.Status == models.Running {
 			i.Log.Infow("ready for zipping", "export-uuid", payload.ID)
-			go i.compressPayload(&payload) // start a go-routine to not block
+			go i.compressPayload(payload) // start a go-routine to not block
 		}
 	case models.StatusPending:
 		return

--- a/models/db.go
+++ b/models/db.go
@@ -28,8 +28,8 @@ type DBInterface interface {
 
 	Create(payload *ExportPayload) error
 	Delete(exportUUID uuid.UUID, user User) error
-	Get(exportUUID uuid.UUID, result *ExportPayload) error
-	GetWithUser(exportUUID uuid.UUID, user User, result *ExportPayload) error
+	Get(exportUUID uuid.UUID) (result *ExportPayload, err error)
+	GetWithUser(exportUUID uuid.UUID, user User) (result *ExportPayload, err error)
 	List(user User) (result []*ExportPayload, err error)
 	Raw(sql string, values ...interface{}) *gorm.DB
 	Updates(m *ExportPayload, values interface{}) error
@@ -49,26 +49,26 @@ func (edb *ExportDB) Delete(exportUUID uuid.UUID, user User) error {
 	return result.Error
 }
 
-func (edb *ExportDB) Get(exportUUID uuid.UUID, result *ExportPayload) error {
-	err := (edb.DB.Model(&ExportPayload{}).
+func (edb *ExportDB) Get(exportUUID uuid.UUID) (result *ExportPayload, err error) {
+	err = (edb.DB.Model(&ExportPayload{}).
 		Where(&ExportPayload{ID: exportUUID}).
 		Take(&result)).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return ErrRecordNotFound
+		return result, ErrRecordNotFound
 	}
-	return err
+	return
 }
 
-func (edb *ExportDB) GetWithUser(exportUUID uuid.UUID, user User, result *ExportPayload) error {
-	err := (edb.DB.Model(&ExportPayload{}).
+func (edb *ExportDB) GetWithUser(exportUUID uuid.UUID, user User) (result *ExportPayload, err error) {
+	err = (edb.DB.Model(&ExportPayload{}).
 		Where(&ExportPayload{ID: exportUUID, User: user}).
 		Take(&result)).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return ErrRecordNotFound
+		return result, ErrRecordNotFound
 	}
-	return err
+	return
 }
 
 func (edb *ExportDB) APIList(user User) (result []*APIExport, err error) {


### PR DESCRIPTION
* align the `Get` and `GetWithUser` with the behavior of `List` and `APIList`: return the model instead of accepting a pointer