### PR TITLE
Remove the kafka and models package from the config package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,11 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 	"github.com/spf13/viper"
-
-	"github.com/redhatinsights/export-service-go/models"
 )
 
 const ExportTopic string = "platform.export.requests"
@@ -37,18 +34,6 @@ type ExportConfig struct {
 	KafkaConfig     kafkaConfig
 	OpenAPIFilePath string
 	Psks            []string
-
-	Channels channels
-}
-
-type channels struct {
-	ProducerMessagesChan chan *kafka.Message
-	ReadyToZip           chan *models.ExportPayload
-}
-
-func (c channels) CloseChannels() {
-	close(c.ProducerMessagesChan)
-	close(c.ReadyToZip)
 }
 
 type dbConfig struct {
@@ -143,11 +128,6 @@ func init() {
 		LogLevel:        options.GetString("LogLevel"),
 		OpenAPIFilePath: options.GetString("OpenAPIFilePath"),
 		Psks:            options.GetStringSlice("psks"),
-	}
-
-	config.Channels = channels{
-		ProducerMessagesChan: make(chan *kafka.Message),        // TODO: determine an appropriate buffer (if one is actually necessary)
-		ReadyToZip:           make(chan *models.ExportPayload), // TODO: determine an appropriate buffer (if one is actually necessary),
 	}
 
 	config.DBConfig = dbConfig{

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -12,9 +12,8 @@ import (
 )
 
 var (
-	cfg     = config.ExportCfg
-	log     = logger.Log
-	msgChan = cfg.Channels.ProducerMessagesChan
+	cfg = config.ExportCfg
+	log = logger.Log
 
 	messagesPublished = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "ingress_kafka_produced",
@@ -44,7 +43,7 @@ func init() {
 type Producer struct{ *kafka.Producer }
 
 // StartProducer produces kafka messages on the kafka topic
-func (p *Producer) StartProducer() {
+func (p *Producer) StartProducer(msgChan chan *kafka.Message) {
 	log.Infof("started kafka producer: %+v", p)
 	topic := cfg.KafkaConfig.ExportsTopic
 	for msg := range msgChan {


### PR DESCRIPTION
Remove the kafka and models packages from the config package.  Having the config package pull in these packages will eventually cause a circular dependency.

Also, move the channel creation out of the config package.  Create the channels in main and inject them into the places where they are needed.