### PR TITLE
Create a job to purge expired reports from the DB [RHCLOUD-21462]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ lint:
 build:
 	$(OCI_TOOL) build . -t $(CONTAINER_TAG)
 
+build-local:
+	go build -o export-service cmd/export-service/*.go
+	go build -o export-service-main main.go
+
 spec:
 ifeq (, $(shell which yq))
 	echo "yq is not installed"
@@ -82,3 +86,6 @@ sample-request-internal-upload:
 
 make test:
 	ginkgo -r --race --randomize-all --randomize-suites
+
+test-sql:
+	go test ./... -tags=sql -count=1

--- a/cmd/export-service/expired_export_cleaner.go
+++ b/cmd/export-service/expired_export_cleaner.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"github.com/redhatinsights/export-service-go/config"
+	"github.com/redhatinsights/export-service-go/db"
+	"github.com/redhatinsights/export-service-go/models"
+
+	"go.uber.org/zap"
+)
+
+func startExpiredExportCleaner(cfg *config.ExportConfig, log *zap.SugaredLogger) {
+
+	log.Info("Starting expired export cleaner")
+
+	dbConnection, err := db.OpenDB(*cfg)
+	if err != nil {
+		log.Panic("failed to open database", "error", err)
+	}
+
+	exportsDB := models.ExportDB{
+		DB:  dbConnection,
+		Cfg: cfg,
+	}
+
+	err = exportsDB.DeleteExpiredExports()
+	if err != nil {
+		log.Error("Expired export cleaner failed", "error", err)
+	}
+}

--- a/cmd/export-service/main.go
+++ b/cmd/export-service/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"os"
+
+	"github.com/redhatinsights/export-service-go/config"
+	"github.com/redhatinsights/export-service-go/logger"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func createRootCommand(cfg *config.ExportConfig, log *zap.SugaredLogger) *cobra.Command {
+
+	// rootCmd represents the base command when called without any subcommands
+	var rootCmd = &cobra.Command{
+		Use: "export-service",
+	}
+
+	var expiredExportCleanerCmd = &cobra.Command{
+		Use:   "expired_export_cleaner",
+		Short: "Run the expired export cleaner",
+		Run: func(cmd *cobra.Command, args []string) {
+			startExpiredExportCleaner(cfg, log)
+		},
+	}
+
+	rootCmd.AddCommand(expiredExportCleanerCmd)
+
+	return rootCmd
+}
+
+func main() {
+	cfg := config.ExportCfg
+	log := logger.Log
+
+	cmd := createRootCommand(cfg, log)
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -22,18 +22,19 @@ var ExportCfg *ExportConfig
 
 // ExportConfig represents the runtime configuration
 type ExportConfig struct {
-	Hostname        string
-	PublicPort      int
-	MetricsPort     int
-	PrivatePort     int
-	Logging         *loggingConfig
-	LogLevel        string
-	Debug           bool
-	DBConfig        dbConfig
-	StorageConfig   storageConfig
-	KafkaConfig     kafkaConfig
-	OpenAPIFilePath string
-	Psks            []string
+	Hostname         string
+	PublicPort       int
+	MetricsPort      int
+	PrivatePort      int
+	Logging          *loggingConfig
+	LogLevel         string
+	Debug            bool
+	DBConfig         dbConfig
+	StorageConfig    storageConfig
+	KafkaConfig      kafkaConfig
+	OpenAPIFilePath  string
+	Psks             []string
+	ExportExpiryDays int
 }
 
 type dbConfig struct {
@@ -92,6 +93,7 @@ func init() {
 	options.SetDefault("Debug", false)
 	options.SetDefault("OpenAPIFilePath", "./static/spec/openapi.json")
 	options.SetDefault("psks", strings.Split(os.Getenv("EXPORTS_PSKS"), ","))
+	options.SetDefault("Export_Expiriy_Days", 7)
 
 	// DB defaults
 	options.SetDefault("PGSQL_USER", "postgres")
@@ -120,14 +122,15 @@ func init() {
 	kubenv.AutomaticEnv()
 
 	config = &ExportConfig{
-		Hostname:        kubenv.GetString("Hostname"),
-		PublicPort:      options.GetInt("PublicPort"),
-		MetricsPort:     options.GetInt("MetricsPort"),
-		PrivatePort:     options.GetInt("PrivatePort"),
-		Debug:           options.GetBool("Debug"),
-		LogLevel:        options.GetString("LogLevel"),
-		OpenAPIFilePath: options.GetString("OpenAPIFilePath"),
-		Psks:            options.GetStringSlice("psks"),
+		Hostname:         kubenv.GetString("Hostname"),
+		PublicPort:       options.GetInt("PublicPort"),
+		MetricsPort:      options.GetInt("MetricsPort"),
+		PrivatePort:      options.GetInt("PrivatePort"),
+		Debug:            options.GetBool("Debug"),
+		LogLevel:         options.GetString("LogLevel"),
+		OpenAPIFilePath:  options.GetString("OpenAPIFilePath"),
+		Psks:             options.GetStringSlice("psks"),
+		ExportExpiryDays: options.GetInt("Export_Expiriy_Days"),
 	}
 
 	config.DBConfig = dbConfig{

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -55,6 +55,29 @@ objects:
             cpu: 500m
             memory: 512Mi
 
+    jobs:
+    - name: cleaner
+      schedule: ${CLEANER_SCHEDULE}
+      restartPolicy: OnFailure
+      concurrencyPolicy: Replace
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        command:
+        - ./export-service-go
+        - expired_export_cleaner
+        env:
+        - name: LOG_LEVEL
+          value: ${LOG_LEVEL}
+        - name: DB_SSLMODE
+          value: ${DB_SSLMODE}
+        resources:
+          limits:
+            cpu: 200m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
+
 
 parameters:
   - description: Cpu limit of service
@@ -82,3 +105,5 @@ parameters:
     value: "false"
   - name: OPEN_API_FILEPATH
     value: /var/tmp/openapi.json
+  - name: CLEANER_SCHEDULE
+    value: "* 1 * * *"

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.12.1
 	github.com/redhatinsights/app-common-go v1.6.0
 	github.com/redhatinsights/platform-go-middlewares v0.12.0
+	github.com/spf13/cobra v0.0.3 // indirect
 	github.com/spf13/viper v1.11.0
 	go.uber.org/zap v1.21.0
 	gorm.io/datatypes v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -375,6 +375,7 @@ github.com/hashicorp/serf v0.9.7/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpT
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
@@ -621,6 +622,7 @@ github.com/spf13/afero v1.8.2 h1:xehSyVa0YnHWsJ49JFljMpg1HX19V6NDZ1fkm1Xznbo=
 github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfAqwo=
 github.com/spf13/cast v1.4.1 h1:s0hze+J0196ZfEMTs80N7UlFt0BDuQ7Q+JDnHiMWKdA=
 github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=

--- a/models/models_suite_test.go
+++ b/models/models_suite_test.go
@@ -1,0 +1,13 @@
+package models_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestModels(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Models Suite")
+}

--- a/models/purge_expired_exports_test.go
+++ b/models/purge_expired_exports_test.go
@@ -1,0 +1,65 @@
+//go:build sql
+// +build sql
+
+package models_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/redhatinsights/export-service-go/config"
+	"github.com/redhatinsights/export-service-go/db"
+	"github.com/redhatinsights/export-service-go/models"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("Purge expired exports", func() {
+
+	var (
+		dbConnection *gorm.DB
+	)
+
+	BeforeEach(func() {
+		var err error
+		dbConnection, err = db.OpenDB(*config.ExportCfg)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	DescribeTable("Test that exports are purged correctly",
+		func(expiresAtTimestamp time.Time, numberOfRowsToCleanup int) {
+
+			sourceID := uuid.New()
+			sourcesJson := fmt.Sprintf("[{\"id\": \"%s\"}]", sourceID)
+
+			export := models.ExportPayload{
+				Expires: &expiresAtTimestamp,
+				Sources: datatypes.JSON([]byte(sourcesJson)),
+			}
+
+			err := dbConnection.Create(&export).Error
+			Expect(err).NotTo(HaveOccurred())
+
+			exportDB := models.ExportDB{
+				DB:  dbConnection,
+				Cfg: config.ExportCfg,
+			}
+
+			err = exportDB.DeleteExpiredExports()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Attempt to delete the record that we inserted before using the id
+			result := dbConnection.Where(&models.ExportPayload{ID: export.ID}).Delete(&models.ExportPayload{})
+
+			// Check that the number of rows that were deleted matches the number
+			// of rows we expected to delete
+			Expect(int(result.RowsAffected)).To(Equal(numberOfRowsToCleanup))
+		},
+		Entry("Export record should be purged", time.Now().AddDate(0, 0, -18), 0),
+		Entry("Export record should NOT be purged", time.Now(), 1),
+	)
+})


### PR DESCRIPTION
Create a job to purge expired reports from the DB [RHCLOUD-21462]

You can run the purge util using this command:
```
./export-service expired_export_cleaner
```

Couple of thoughts/questions/things to discuss about this:

* This pr adds a "purge expired exports" util as a viper subcommand.  I like the viper subcommand approach, but others may not.  Let me know.  If we continue with the viper subcommand approach, then we can create subcommand for starting the api, running the database migration, etc.
* I added a couple of automated tests that actually hit the database to test this logic.  If you have a database instance running, then you can run the tests by running `make test-sql`.  The tests are tagged with "sql".  So they do not run with the "normal" unit tests.

Manual Testing:
Test data can be inserted like this:
insert into export_payloads (id, created_at, updated_at, expires, account_id, organization_id) values (gen_random_uuid(), now(), now(), now() - interval '10 days', '1234', '4567');
insert into export_payloads (id, created_at, updated_at, expires, account_id, organization_id) values (gen_random_uuid(), now(), now(), now(), '1234', '4567');

This should result in one record that should be purged and one record that should not be purged.