### PR TITLE
[RHCLOUD-22711] Fixes to API spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Ports now exposed:
 - metrics on localhost:9090
 - internal api on localhost:10010
 - minio on localhost:9099
+- psql on localhost:5432
 (use `minio` as the access key and `minioadmin` as the secret key to view the dashboard)
+(use `psql -h localhost -p 5432 -U postgres` and the pass `postgres` to connect to the db)
 
 To test local changes, you can restart the api server using `make run-api`.
 

--- a/middleware/pagination.go
+++ b/middleware/pagination.go
@@ -58,7 +58,7 @@ func indexSlice(data interface{}, start, stop int) interface{} {
 		s := reflect.ValueOf(data)
 		len := s.Len()
 		if len == 0 {
-			return s
+			return []interface{}{}
 		}
 		if start > len {
 			return []interface{}{}

--- a/middleware/pagination.go
+++ b/middleware/pagination.go
@@ -168,6 +168,7 @@ func getLinks(url *url.URL, p Paginate, data interface{}) Links {
 	result := Links{First: getFirstLink(url)}
 	count := lenSlice(data)
 	if count <= p.Limit && p.Offset == 0 {
+		result.Last = &result.First
 		return result
 	}
 	result.Next = getNextLink(url, count, p.Limit, p.Offset)

--- a/static/spec/openapi.json
+++ b/static/spec/openapi.json
@@ -146,12 +146,12 @@
         ]
       }
     },
-    "/api/export/v1/exports/{uuid}": {
+    "/api/export/v1/exports/{id}": {
       "get": {
         "operationId": "downloadExport",
         "parameters": [
           {
-            "name": "uuid",
+            "name": "id",
             "in": "path",
             "schema": {
               "$ref": "#/components/schemas/UUID"
@@ -182,7 +182,7 @@
         "operationId": "deleteExport",
         "parameters": [
           {
-            "name": "uuid",
+            "name": "id",
             "in": "path",
             "schema": {
               "$ref": "#/components/schemas/UUID"
@@ -202,12 +202,12 @@
         ]
       }
     },
-    "/api/export/v1/exports/{uuid}/status": {
+    "/api/export/v1/exports/{id}/status": {
       "get": {
         "operationId": "getExportStatus",
         "parameters": [
           {
-            "name": "uuid",
+            "name": "id",
             "in": "path",
             "schema": {
               "$ref": "#/components/schemas/UUID"
@@ -234,12 +234,12 @@
         ]
       }
     },
-    "/app/export/v1/upload/{uuid}/{application}/{resource}": {
+    "/app/export/v1/upload/{id}/{application}/{resource}": {
       "post": {
         "operationId": "downloadExportUpload",
         "parameters": [
           {
-            "name": "uuid",
+            "name": "id",
             "in": "path",
             "schema": {
               "$ref": "#/components/schemas/UUID"
@@ -288,12 +288,12 @@
         ]
       }
     },
-    "/app/export/v1/error/{uuid}/{application}/{resource}": {
+    "/app/export/v1/error/{id}/{application}/{resource}": {
       "post": {
         "operationId": "downloadExportError",
         "parameters": [
           {
-            "name": "uuid",
+            "name": "id",
             "in": "path",
             "schema": {
               "$ref": "#/components/schemas/UUID"
@@ -366,9 +366,13 @@
       "ExportResource": {
         "type": "object",
         "required": [
+          "application",
           "resource"
         ],
         "properties": {
+          "application": {
+            "type": "string"
+          },
           "resource": {
             "type": "string"
           },
@@ -386,20 +390,16 @@
         "required": [
           "name",
           "format",
-          "application",
           "sources"
         ],
         "properties": {
           "name": {
             "type": "string"
           },
-          "application": {
-            "type": "string"
-          },
           "format": {
             "$ref": "#/components/schemas/Format"
           },
-          "resources": {
+          "sources": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ExportResource"
@@ -410,14 +410,14 @@
       "ExportStatus": {
         "type": "object",
         "required": [
-          "uuid",
+          "id",
           "name",
           "created",
           "format",
           "status"
         ],
         "properties": {
-          "uuid": {
+          "id": {
             "$ref": "#/components/schemas/UUID"
           },
           "name": {
@@ -441,7 +441,8 @@
           "status": {
             "type": "string",
             "enum": [
-              "scheduled",
+              "partial",
+              "pending",
               "running",
               "complete",
               "failed"
@@ -456,10 +457,12 @@
             "type": "string"
           },
           "next": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "previous": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "last": {
             "type": "string"

--- a/static/spec/openapi.yaml
+++ b/static/spec/openapi.yaml
@@ -88,11 +88,11 @@ paths:
                 $ref: '#/components/schemas/ExportList'
       security:
         - 3ScaleIdentity: []
-  /api/export/v1/exports/{uuid}:
+  /api/export/v1/exports/{id}:
     get:
       operationId: downloadExport
       parameters:
-        - name: uuid
+        - name: id
           in: path
           schema:
             $ref: '#/components/schemas/UUID'
@@ -110,7 +110,7 @@ paths:
     delete:
       operationId: deleteExport
       parameters:
-        - name: uuid
+        - name: id
           in: path
           schema:
             $ref: '#/components/schemas/UUID'
@@ -120,11 +120,11 @@ paths:
           description: Export deleted (if it existed)
       security:
         - 3ScaleIdentity: []
-  /api/export/v1/exports/{uuid}/status:
+  /api/export/v1/exports/{id}/status:
     get:
       operationId: getExportStatus
       parameters:
-        - name: uuid
+        - name: id
           in: path
           schema:
             $ref: '#/components/schemas/UUID'
@@ -140,11 +140,11 @@ paths:
         - 3ScaleIdentity: []
 
 #internal
-  /app/export/v1/upload/{uuid}/{application}/{resource}:
+  /app/export/v1/upload/{id}/{application}/{resource}:
     post:
       operationId: downloadExportUpload
       parameters:
-        - name: uuid
+        - name: id
           in: path
           schema:
             $ref: '#/components/schemas/UUID'
@@ -172,11 +172,11 @@ paths:
         - psk: []
       tags:
         - internal
-  /app/export/v1/error/{uuid}/{application}/{resource}:
+  /app/export/v1/error/{id}/{application}/{resource}:
     post:
       operationId: downloadExportError
       parameters:
-        - name: uuid
+        - name: id
           in: path
           schema:
             $ref: '#/components/schemas/UUID'
@@ -223,8 +223,11 @@ components:
     ExportResource:
       type: object
       required:
+        - application
         - resource
       properties:
+        application:
+          type: string
         resource:
           type: string
         expires:
@@ -237,29 +240,26 @@ components:
       required:
         - name
         - format
-        - application
         - sources
       properties:
         name:
           type: string
-        application:
-          type: string
         format:
           $ref: '#/components/schemas/Format'
-        resources:
+        sources:
           type: array
           items:
             $ref: '#/components/schemas/ExportResource'
     ExportStatus:
       type: object
       required:
-        - uuid
+        - id
         - name
         - created
         - format
         - status
       properties:
-        uuid:
+        id:
           $ref: '#/components/schemas/UUID'
         name:
           type: string
@@ -277,7 +277,8 @@ components:
         status:
           type: string
           enum:
-            - scheduled
+            - partial
+            - pending
             - running
             - complete
             - failed
@@ -288,8 +289,10 @@ components:
           type: string
         next:
           type: string
+          nullable: true
         previous:
           type: string
+          nullable: true
         last:
           type: string
       required:


### PR DESCRIPTION
[RHCLOUD-22711](https://issues.redhat.com/browse/RHCLOUD-22711)

**Fixed the following:**
- [x] In the spec file it says it's expecting a "uuid" to be returned in a ExportStatus, but the json field is labeled "id"
> Changed fields named `uuid` to `id`
- [x] The spec file says that a "pending" status is valid for ExportStatus, but it does not exist in the status field
> Updated the ExportStatus fields to match those in the codebase
- [x] The PageLinks properties first, last, next, and previous could all return "null" which isn't accounted for in the spec file
> Last was updated so that it should never return `null`. Next and Previous have been set to `nullable` in the spec
- [x] Having an empty database and doing get_exports returns empty dict, and a list of dicts is what the api is specifying.
> An empty list is now returned from and empty listExports response, instead of an empty object
- [x] Change `resources` to `sources`
> Changed the spec to match usage of `sources` in the codebase

**Note:** There are still existing issues with pagination that will be handled in an upcoming PR. See https://github.com/RedHatInsights/export-service-go/pull/31