### PR TITLE
Remove db init() and pass cfg explicitly

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -13,36 +13,13 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/redhatinsights/export-service-go/config"
-	"github.com/redhatinsights/export-service-go/logger"
-	"github.com/redhatinsights/export-service-go/models"
 )
 
-// DB is a global variable containing the gorm.DB
-var DB *gorm.DB
-
-var (
-	cfg = config.ExportCfg
-	log = logger.Log
-)
-
-func init() {
+func OpenDB(cfg config.ExportConfig) (*gorm.DB, error) {
 	dbcfg := cfg.DBConfig
 	dsn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", dbcfg.User, dbcfg.Password, dbcfg.Hostname, dbcfg.Port, dbcfg.Name, dbcfg.SSLCfg.SSLMode)
 	if dbcfg.SSLCfg.RdsCa != nil && *dbcfg.SSLCfg.RdsCa != "" {
 		dsn += fmt.Sprintf("&sslrootcert=%s", *dbcfg.SSLCfg.RdsCa)
 	}
-	var err error
-	DB, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		panic("failed to connect database")
-	}
-
-	var greeting string
-	DB.Raw("select 'Hello, from Postgres!!'").Scan(&greeting)
-	log.Info(greeting)
-
-	// all models go here for migration
-	if err := DB.AutoMigrate(&models.ExportPayload{}); err != nil {
-		log.Panicw("failed to migrate db", "error", err)
-	}
+	return gorm.Open(postgres.Open(dsn), &gorm.Config{})
 }


### PR DESCRIPTION
removed the `init()` function that was used to initialize the database connection as a global and instead explicitly open the database connection when needed. The database configuration is now passed to the function that opens the database connection.