### PR TITLE
Set correct minio default port

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -102,7 +102,7 @@ func init() {
 
 	// Minio defaults
 	options.SetDefault("MINIO_HOST", "localhost")
-	options.SetDefault("MINIO_PORT", "9000")
+	options.SetDefault("MINIO_PORT", "9099")
 	options.SetDefault("MINIO_SSL", false)
 
 	// Kafka defaults


### PR DESCRIPTION
Attempt to fix https://issues.redhat.com/browse/RHCLOUD-23696

Set the default port for minio to 9099 (instead of 9000 which is used for the metrics endpoint)