### PR TITLE
Modify the readiness and liveness probes to hit the metrics server

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -23,8 +23,8 @@ objects:
         livenessProbe:        
           failureThreshold: 3
           httpGet:
-            path: /
-            port: 8000
+            path: /healthz
+            port: 9000
             scheme: HTTP
           initialDelaySeconds: 35
           periodSeconds: 5
@@ -33,8 +33,8 @@ objects:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /
-            port: 8000
+            path: /readyz
+            port: 9000
             scheme: HTTP
           initialDelaySeconds: 35
           periodSeconds: 5


### PR DESCRIPTION
Right now the readiness and liveness probes hit the public web server.  This isn't necessarily bad, but that server logs each request (response code, etc)....so the logs get overrun with useless info.