### PR TITLE
Make api server command a subcommand

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN go mod download
 # Now copy the rest of the files for build
 COPY . .
 # Build the binary
-RUN GO111MODULE=on go build -ldflags "-w -s" -o export-service
+RUN GO111MODULE=on go build -ldflags "-w -s" -o export-service cmd/export-service/*.go
 ############################
 # STEP 2 build a small image
 ############################

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ build:
 
 build-local:
 	go build -o export-service cmd/export-service/*.go
-	go build -o export-service-main main.go
 
 spec:
 ifeq (, $(shell which yq))
@@ -60,8 +59,8 @@ docker-up-no-server: docker-up-db
 monitor-topic:
 	$(OCI_TOOL) exec -ti kafka /usr/bin/kafka-console-consumer --bootstrap-server localhost:9092 --topic platform.export.requests
 
-run-api:
-	DEBUG=true MINIO_PORT=9099 AWS_ACCESS_KEY=minio AWS_SECRET_ACCESS_KEY=minioadmin PSKS=testing-a-psk PUBLICPORT=8000 METRICSPORT=9090 PRIVATEPORT=10010 PGSQL_PORT=5432 go run main.go
+run-api: build-local
+	DEBUG=true MINIO_PORT=9099 AWS_ACCESS_KEY=minio AWS_SECRET_ACCESS_KEY=minioadmin PSKS=testing-a-psk PUBLICPORT=8000 METRICSPORT=9090 PRIVATEPORT=10010 PGSQL_PORT=5432 ./export-service api_server
 
 run: docker-up-no-server run-api
 

--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -167,7 +167,7 @@ func serveOpenAPISpec(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, cfg.OpenAPIFilePath)
 }
 
-func main() {
+func startApiServer(cfg *config.ExportConfig, log *zap.SugaredLogger) {
 	log.Infow("configuration values",
 		"hostname", cfg.Hostname,
 		"publicport", cfg.PublicPort,

--- a/cmd/export-service/main.go
+++ b/cmd/export-service/main.go
@@ -27,6 +27,16 @@ func createRootCommand(cfg *config.ExportConfig, log *zap.SugaredLogger) *cobra.
 
 	rootCmd.AddCommand(expiredExportCleanerCmd)
 
+	var apiServerCmd = &cobra.Command{
+		Use:   "api_server",
+		Short: "Run the api server",
+		Run: func(cmd *cobra.Command, args []string) {
+			startApiServer(cfg, log)
+		},
+	}
+
+	rootCmd.AddCommand(apiServerCmd)
+
 	return rootCmd
 }
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -20,6 +20,9 @@ objects:
       # Details about running pod
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}     
+        command:
+        - export-service-go
+        - api_server
         livenessProbe:        
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
This PR makes the api server a subcommand and removes the main.go.

This means that to start the server, you will need to run `./export-service api_server`.