### PR TITLE
Try to get the s3 client working with minio in ephemeral

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -144,7 +144,7 @@ func init() {
 
 	config.StorageConfig = storageConfig{
 		Bucket:    "exports-bucket",
-		Endpoint:  fmt.Sprintf("http://%s:%s", options.GetString("MINIO_HOST"), options.GetString("MINIO_PORT")),
+		Endpoint:  buildBaseHttpUrl(options.GetBool("MINIO_SSL"), options.GetString("MINIO_HOST"), options.GetInt("MINIO_PORT")),
 		AccessKey: options.GetString("AWS_ACCESS_KEY"),
 		SecretKey: options.GetString("AWS_SECRET_ACCESS_KEY"),
 		UseSSL:    options.GetBool("MINIO_SSL"),
@@ -201,11 +201,10 @@ func init() {
 			Region:          cfg.Logging.Cloudwatch.Region,
 		}
 
-		endpoint := fmt.Sprintf("%s:%d", cfg.ObjectStore.Hostname, cfg.ObjectStore.Port)
 		bucket := cfg.ObjectStore.Buckets[0]
 		config.StorageConfig = storageConfig{
 			Bucket:    exportBucketInfo.RequestedName,
-			Endpoint:  endpoint,
+			Endpoint:  buildBaseHttpUrl(cfg.ObjectStore.Tls, cfg.ObjectStore.Hostname, cfg.ObjectStore.Port),
 			AccessKey: *bucket.AccessKey,
 			SecretKey: *bucket.SecretKey,
 			UseSSL:    cfg.ObjectStore.Tls,
@@ -213,4 +212,13 @@ func init() {
 	}
 
 	ExportCfg = config
+}
+
+func buildBaseHttpUrl(tlsEnabled bool, hostname string, port int) string {
+	var protocol string = "http"
+	if tlsEnabled {
+		protocol = "https"
+	}
+
+	return fmt.Sprintf("%s://%s:%d", protocol, hostname, port)
 }

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -16,21 +16,17 @@ var (
 	log    = logger.Log
 )
 
+const defaultRegion = "us-east-1"
+
 func init() {
 	scfg := cfg.StorageConfig
 
 	resolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-		if cfg.Debug {
-			return aws.Endpoint{
-				URL:               scfg.Endpoint,
-				HostnameImmutable: true,
-			}, nil
-		}
-
-		// returning EndpointNotFoundError will allow the service to fallback to it's default resolution
 		return aws.Endpoint{
-			URL: scfg.Endpoint,
-		}, &aws.EndpointNotFoundError{}
+			URL:               scfg.Endpoint,
+			SigningRegion:     defaultRegion,
+			HostnameImmutable: true,
+		}, nil
 	})
 
 	creds := aws.CredentialsProviderFunc(func(c context.Context) (aws.Credentials, error) {
@@ -41,7 +37,7 @@ func init() {
 	})
 
 	s3cfg := aws.Config{
-		Region:                      "us-east-1",
+		Region:                      defaultRegion,
 		Credentials:                 creds,
 		EndpointResolverWithOptions: resolver,
 	}


### PR DESCRIPTION
I think this works.  I'm not sure what the `&aws.EndpointNotFoundError{}` bit was doing before, but minio in ephemeral does not like it.

The region should probably be configurable??