### PR TITLE
Enable gh action run against main branch with push event

### DIFF
--- a/.github/workflows/ginkgo-test.yaml
+++ b/.github/workflows/ginkgo-test.yaml
@@ -1,5 +1,6 @@
 name: ginkgo-test
 on:
+  push:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
We don't have run against main/master branch
https://github.com/RedHatInsights/export-service-go/actions/workflows/ginkgo-test.yaml?query=branch%3Amain

