### PR TITLE
Remove some global variables

### DIFF
--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -193,15 +193,9 @@ func startApiServer(cfg *config.ExportConfig, log *zap.SugaredLogger) {
 	}
 	wsrv := createPublicServer(cfg, external)
 
-	compressor := es3.Compressor{
-		Bucket: cfg.StorageConfig.Bucket,
-		Log:    log,
-		Client: *es3.Client,
-	}
-
 	internal := exports.Internal{
 		Cfg:        cfg,
-		Compressor: &compressor,
+		Compressor: &storageHandler,
 		DB:         &models.ExportDB{DB: DB},
 		Log:        log,
 	}


### PR DESCRIPTION
Remove some global variables from the api server startup code

Modified the api server code to share the compressor/storage handler instance between the internal and external servers.  It looks like the different instances were sharing the same instances of their dependencies (logger, s3 client, etc).  Let me know if this is an issue.