### PR TITLE
Add metric to track failed uploads

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -19,6 +19,14 @@ var httpReqs = prometheus.NewCounterVec(
 	[]string{"code", "method", "path"},
 )
 
+var failedUploads = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "failed_uploads_total",
+		Help: "Number of failed uploads by error type.",
+	},
+	[]string{"error_type"},
+)
+
 var httpDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Name: "http_response_time_seconds",
 	Help: "Duration of HTTP requests, partitioned by path.",
@@ -55,4 +63,5 @@ func PrometheusMiddleware(next http.Handler) http.Handler {
 func init() {
 	prometheus.MustRegister(httpReqs)
 	prometheus.MustRegister(httpDuration)
+	prometheus.MustRegister(failedUploads)
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -19,14 +19,6 @@ var httpReqs = prometheus.NewCounterVec(
 	[]string{"code", "method", "path"},
 )
 
-var failedUploads = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "failed_uploads_total",
-		Help: "Number of failed uploads by error type.",
-	},
-	[]string{"error_type"},
-)
-
 var httpDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Name: "http_response_time_seconds",
 	Help: "Duration of HTTP requests, partitioned by path.",
@@ -63,5 +55,4 @@ func PrometheusMiddleware(next http.Handler) http.Handler {
 func init() {
 	prometheus.MustRegister(httpReqs)
 	prometheus.MustRegister(httpDuration)
-	prometheus.MustRegister(failedUploads)
 }

--- a/s3/compress.go
+++ b/s3/compress.go
@@ -17,7 +17,6 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redhatinsights/export-service-go/models"
 )
 
@@ -234,13 +233,6 @@ func (c *Compressor) Upload(ctx context.Context, body io.Reader, bucket, key *st
 func (c *Compressor) CreateObject(ctx context.Context, db models.DBInterface, body io.Reader, urlparams *models.URLParams, payload *models.ExportPayload) error {
 	filename := fmt.Sprintf("%s/%s/%s.%s", payload.OrganizationID, payload.ID, urlparams.ResourceUUID, payload.Format)
 
-	var failedUploads = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "failed_uploads_total",
-		Help: "The total number of failed S3 uploads.",
-	})
-
-	prometheus.MustRegister(failedUploads)
-
 	if err := payload.SetStatusRunning(db); err != nil {
 		c.Log.Errorw("failed to set running status", "error", err)
 		return err
@@ -248,7 +240,7 @@ func (c *Compressor) CreateObject(ctx context.Context, db models.DBInterface, bo
 
 	_, uploadErr := c.Upload(ctx, body, &c.Bucket, &filename)
 	if uploadErr != nil {
-		defer failedUploads.Inc()
+		failUploads.Inc()
 		c.Log.Errorf("error during upload: %v", uploadErr)
 		statusError := models.SourceError{Message: uploadErr.Error(), Code: 1} // TODO: determine a better approach to assigning an internal status code
 		if err := payload.SetSourceStatus(db, urlparams.ResourceUUID, models.RFailed, &statusError); err != nil {

--- a/s3/metrics.go
+++ b/s3/metrics.go
@@ -1,0 +1,14 @@
+package s3
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var failUploads = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "fail_uploads_total",
+	Help: "The total number of failed S3 uploads.",
+})
+
+func init() {
+	prometheus.MustRegister(failUploads)
+}

--- a/s3/metrics.go
+++ b/s3/metrics.go
@@ -5,7 +5,7 @@ import (
 )
 
 var failUploads = prometheus.NewCounter(prometheus.CounterOpts{
-	Name: "fail_uploads_total",
+	Name: "failed_s3_uploads",
 	Help: "The total number of failed S3 uploads.",
 })
 


### PR DESCRIPTION
- Story: [RHCLOUD-23982](https://issues.redhat.com/browse/RHCLOUD-23982)
- Added a Prometheus countervec called 'faileduploads' that tracks the number of failed uploads by error type 