### PR TITLE
Moving URLParams out of models and moving to Middleware

### DIFF
--- a/exports/internal.go
+++ b/exports/internal.go
@@ -13,7 +13,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/redhatinsights/export-service-go/config"
-	"github.com/redhatinsights/export-service-go/errors"
 	"github.com/redhatinsights/export-service-go/middleware"
 	"github.com/redhatinsights/export-service-go/models"
 	"github.com/redhatinsights/export-service-go/s3"
@@ -42,14 +41,14 @@ func (i *Internal) InternalRouter(r chi.Router) {
 func (i *Internal) PostError(w http.ResponseWriter, r *http.Request) {
 	params := middleware.GetURLParams(r.Context())
 	if params == nil {
-		errors.InternalServerError(w, "unable to parse url params")
+		InternalServerError(w, "unable to parse url params")
 		return
 	}
 
 	var sourceError models.SourceError
 	err := json.NewDecoder(r.Body).Decode(&sourceError)
 	if err != nil {
-		errors.BadRequestError(w, err.Error())
+		BadRequestError(w, err.Error())
 		return
 	}
 
@@ -57,11 +56,11 @@ func (i *Internal) PostError(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch err {
 		case models.ErrRecordNotFound:
-			errors.NotFoundError(w, fmt.Sprintf("record '%s' not found", params.ExportUUID))
+			NotFoundError(w, fmt.Sprintf("record '%s' not found", params.ExportUUID))
 			return
 		default:
 			i.Log.Errorw("error querying for payload entry", "error", err)
-			errors.InternalServerError(w, err)
+			InternalServerError(w, err)
 			return
 		}
 	}
@@ -69,14 +68,14 @@ func (i *Internal) PostError(w http.ResponseWriter, r *http.Request) {
 	_, source, err := payload.GetSource(params.ResourceUUID)
 	if err != nil {
 		i.Log.Errorw("failed to get source: %w", err)
-		errors.InternalServerError(w, err.Error())
+		InternalServerError(w, err.Error())
 		return
 	}
 
 	if source.Status == models.RSuccess || source.Status == models.RFailed {
 		// TODO: revisit this logic and response. Do we want to allow a re-write of an already completed source?
 		w.WriteHeader(http.StatusGone)
-		errors.Logerr(w.Write([]byte("this resource has already been processed")))
+		Logerr(w.Write([]byte("this resource has already been processed")))
 		return
 	}
 
@@ -84,13 +83,13 @@ func (i *Internal) PostError(w http.ResponseWriter, r *http.Request) {
 
 	if err := payload.SetSourceStatus(i.DB, params.ResourceUUID, models.RFailed, &sourceError); err != nil {
 		i.Log.Errorw("failed to set source status for failed export", "error", err)
-		errors.InternalServerError(w, err)
+		InternalServerError(w, err)
 		return
 	}
 
 	if err := payload.SetStatusRunning(i.DB); err != nil {
 		i.Log.Errorw("failed to save status update for failed export", "error", err)
-		errors.InternalServerError(w, err)
+		InternalServerError(w, err)
 	}
 
 	i.Compressor.ProcessSources(i.DB, params.ExportUUID)
@@ -102,7 +101,7 @@ func (i *Internal) PostUpload(w http.ResponseWriter, r *http.Request) {
 	i.Log.Info("received payload")
 	params := middleware.GetURLParams(r.Context())
 	if params == nil {
-		errors.InternalServerError(w, "unable to parse url params")
+		InternalServerError(w, "unable to parse url params")
 		return
 	}
 
@@ -110,11 +109,11 @@ func (i *Internal) PostUpload(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch err {
 		case models.ErrRecordNotFound:
-			errors.NotFoundError(w, fmt.Sprintf("record '%s' not found", params.ExportUUID))
+			NotFoundError(w, fmt.Sprintf("record '%s' not found", params.ExportUUID))
 			return
 		default:
 			i.Log.Errorw("error querying for payload entry", "error", err)
-			errors.InternalServerError(w, err)
+			InternalServerError(w, err)
 			return
 		}
 	}
@@ -122,28 +121,28 @@ func (i *Internal) PostUpload(w http.ResponseWriter, r *http.Request) {
 	_, source, err := payload.GetSource(params.ResourceUUID)
 	if err != nil {
 		i.Log.Errorf("failed to get source: %w", err)
-		errors.InternalServerError(w, err.Error())
+		InternalServerError(w, err.Error())
 		return
 	}
 
 	if source.Status == models.RSuccess || source.Status == models.RFailed {
 		// TODO: revisit this logic and response. Do we want to allow a re-write of an already zipped package?
 		w.WriteHeader(http.StatusGone)
-		errors.Logerr(w.Write([]byte("this resource has already been processed")))
+		Logerr(w.Write([]byte("this resource has already been processed")))
 		return
 	}
 
 	w.WriteHeader(http.StatusAccepted)
 
-	if err := i.Compressor.CreateObject(r.Context(), i.DB, r.Body, params, payload); err != nil {
-		errors.Logerr(w.Write([]byte(fmt.Sprintf("payload failed to upload: %v", err))))
+	if err := i.Compressor.CreateObject(r.Context(), i.DB, r.Body, params.ExportUUID, payload); err != nil {
+		Logerr(w.Write([]byte(fmt.Sprintf("payload failed to upload: %v", err))))
 	} else {
-		errors.Logerr(w.Write([]byte("payload delivered")))
+		Logerr(w.Write([]byte("payload delivered")))
 	}
 
 	if err := payload.SetSourceStatus(i.DB, params.ResourceUUID, models.RSuccess, nil); err != nil {
 		i.Log.Errorw("failed to set source status for successful export", "error", err)
-		errors.InternalServerError(w, err)
+		InternalServerError(w, err)
 	}
 
 	i.Compressor.ProcessSources(i.DB, params.ExportUUID)

--- a/middleware/internal.go
+++ b/middleware/internal.go
@@ -66,6 +66,6 @@ func URLParamsCtx(next http.Handler) http.Handler {
 }
 
 // GetURLParams fetches the urlParams from the context.
-func GetURLParams(ctx context.Context) *URLParams {
-	return ctx.Value(urlParamsKey).(*URLParams)
+func GetURLParams(ctx context.Context) URLParams {
+	return ctx.Value(urlParamsKey).(URLParams)
 }

--- a/middleware/internal.go
+++ b/middleware/internal.go
@@ -54,7 +54,7 @@ func URLParamsCtx(next http.Handler) http.Handler {
 
 		application := chi.URLParam(r, "application")
 
-		params := URLParams{
+		params := &URLParams{
 			ExportUUID:   exportUUID,
 			Application:  application,
 			ResourceUUID: resourceUUID,

--- a/middleware/internal.go
+++ b/middleware/internal.go
@@ -13,12 +13,19 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/redhatinsights/export-service-go/errors"
-	"github.com/redhatinsights/export-service-go/models"
 )
 
 type internalKey int
 
 const urlParamsKey internalKey = iota
+
+// URLParams represent the `exportUUID`, `resourceUUID`, and `application` found in
+// the url. These are added to the request context using the URLParams middleware.
+type URLParams struct {
+	ExportUUID   uuid.UUID
+	Application  string
+	ResourceUUID uuid.UUID
+}
 
 // IsValidUUID is a helper function that checks if the given string is a valid uuid.
 func IsValidUUID(id string) bool {
@@ -47,7 +54,7 @@ func URLParamsCtx(next http.Handler) http.Handler {
 
 		application := chi.URLParam(r, "application")
 
-		params := &models.URLParams{
+		params := URLParams{
 			ExportUUID:   exportUUID,
 			Application:  application,
 			ResourceUUID: resourceUUID,
@@ -59,6 +66,6 @@ func URLParamsCtx(next http.Handler) http.Handler {
 }
 
 // GetURLParams fetches the urlParams from the context.
-func GetURLParams(ctx context.Context) *models.URLParams {
-	return ctx.Value(urlParamsKey).(*models.URLParams)
+func GetURLParams(ctx context.Context) *URLParams {
+	return ctx.Value(urlParamsKey).(*URLParams)
 }

--- a/middleware/internal.go
+++ b/middleware/internal.go
@@ -66,6 +66,6 @@ func URLParamsCtx(next http.Handler) http.Handler {
 }
 
 // GetURLParams fetches the urlParams from the context.
-func GetURLParams(ctx context.Context) URLParams {
-	return ctx.Value(urlParamsKey).(URLParams)
+func GetURLParams(ctx context.Context) *URLParams {
+	return ctx.Value(urlParamsKey).(*URLParams)
 }

--- a/models/models.go
+++ b/models/models.go
@@ -55,14 +55,6 @@ const (
 	RFailed  ResourceStatus = "failed"
 )
 
-// URLParams represent the `exportUUID`, `resourceUUID`, and `application` found in
-// the url. These are added to the request context using the URLParams middleware.
-type URLParams struct {
-	ExportUUID   uuid.UUID
-	Application  string
-	ResourceUUID uuid.UUID
-}
-
 // QueryParams for the /export/v1/exports endpoint
 type QueryParams struct {
 	Name        string

--- a/s3/compress.go
+++ b/s3/compress.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/redhatinsights/export-service-go/middleware"
 	"github.com/redhatinsights/export-service-go/models"
 )
 
@@ -39,7 +40,7 @@ type StorageHandler interface {
 	Compress(ctx context.Context, m *models.ExportPayload) (time.Time, string, string, error)
 	Download(ctx context.Context, w io.WriterAt, bucket, key *string) (n int64, err error)
 	Upload(ctx context.Context, body io.Reader, bucket, key *string) (*manager.UploadOutput, error)
-	CreateObject(ctx context.Context, db models.DBInterface, body io.Reader, urlparams *models.URLParams, payload *models.ExportPayload) error
+	CreateObject(ctx context.Context, db models.DBInterface, body io.Reader, urlparams *middleware.URLParams, payload *models.ExportPayload) error
 	GetObject(ctx context.Context, key string) (io.ReadCloser, error)
 	ProcessSources(db models.DBInterface, uid uuid.UUID)
 }
@@ -230,7 +231,7 @@ func (c *Compressor) Upload(ctx context.Context, body io.Reader, bucket, key *st
 	return uploader.Upload(ctx, input)
 }
 
-func (c *Compressor) CreateObject(ctx context.Context, db models.DBInterface, body io.Reader, urlparams *models.URLParams, payload *models.ExportPayload) error {
+func (c *Compressor) CreateObject(ctx context.Context, db models.DBInterface, body io.Reader, urlparams *middleware.URLParams, payload *models.ExportPayload) error {
 	filename := fmt.Sprintf("%s/%s/%s.%s", payload.OrganizationID, payload.ID, urlparams.ResourceUUID, payload.Format)
 
 	if err := payload.SetStatusRunning(db); err != nil {
@@ -338,7 +339,7 @@ func (mc *MockStorageHandler) Upload(ctx context.Context, body io.Reader, bucket
 	return nil, nil
 }
 
-func (mc *MockStorageHandler) CreateObject(ctx context.Context, db models.DBInterface, body io.Reader, urlparams *models.URLParams, payload *models.ExportPayload) error {
+func (mc *MockStorageHandler) CreateObject(ctx context.Context, db models.DBInterface, body io.Reader, urlparams *middleware.URLParams, payload *models.ExportPayload) error {
 	fmt.Println("Ran mockStorageHandler.CreateObject")
 	return nil
 }


### PR DESCRIPTION
## What?
Removing Dependency between models and middleware, by moving types that are not being used in models to middleware https://issues.redhat.com/browse/RHCLOUD-24681

## Why?
To Remove dependency, cleaning up 

## How?
Moved URL Params struct where it was being used in middleware since it was not being used in models. 
