### PR TITLE
Move Errors to exports

### DIFF
--- a/exports/internal.go
+++ b/exports/internal.go
@@ -13,7 +13,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/redhatinsights/export-service-go/config"
-	"github.com/redhatinsights/export-service-go/errors"
 	"github.com/redhatinsights/export-service-go/middleware"
 	"github.com/redhatinsights/export-service-go/models"
 	"github.com/redhatinsights/export-service-go/s3"
@@ -42,14 +41,14 @@ func (i *Internal) InternalRouter(r chi.Router) {
 func (i *Internal) PostError(w http.ResponseWriter, r *http.Request) {
 	params := middleware.GetURLParams(r.Context())
 	if params == nil {
-		errors.InternalServerError(w, "unable to parse url params")
+		InternalServerError(w, "unable to parse url params")
 		return
 	}
 
 	var sourceError models.SourceError
 	err := json.NewDecoder(r.Body).Decode(&sourceError)
 	if err != nil {
-		errors.BadRequestError(w, err.Error())
+		BadRequestError(w, err.Error())
 		return
 	}
 
@@ -57,11 +56,11 @@ func (i *Internal) PostError(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch err {
 		case models.ErrRecordNotFound:
-			errors.NotFoundError(w, fmt.Sprintf("record '%s' not found", params.ExportUUID))
+			NotFoundError(w, fmt.Sprintf("record '%s' not found", params.ExportUUID))
 			return
 		default:
 			i.Log.Errorw("error querying for payload entry", "error", err)
-			errors.InternalServerError(w, err)
+			InternalServerError(w, err)
 			return
 		}
 	}
@@ -69,14 +68,14 @@ func (i *Internal) PostError(w http.ResponseWriter, r *http.Request) {
 	_, source, err := payload.GetSource(params.ResourceUUID)
 	if err != nil {
 		i.Log.Errorw("failed to get source: %w", err)
-		errors.InternalServerError(w, err.Error())
+		InternalServerError(w, err.Error())
 		return
 	}
 
 	if source.Status == models.RSuccess || source.Status == models.RFailed {
 		// TODO: revisit this logic and response. Do we want to allow a re-write of an already completed source?
 		w.WriteHeader(http.StatusGone)
-		errors.Logerr(w.Write([]byte("this resource has already been processed")))
+		Logerr(w.Write([]byte("this resource has already been processed")))
 		return
 	}
 
@@ -84,13 +83,13 @@ func (i *Internal) PostError(w http.ResponseWriter, r *http.Request) {
 
 	if err := payload.SetSourceStatus(i.DB, params.ResourceUUID, models.RFailed, &sourceError); err != nil {
 		i.Log.Errorw("failed to set source status for failed export", "error", err)
-		errors.InternalServerError(w, err)
+		InternalServerError(w, err)
 		return
 	}
 
 	if err := payload.SetStatusRunning(i.DB); err != nil {
 		i.Log.Errorw("failed to save status update for failed export", "error", err)
-		errors.InternalServerError(w, err)
+		InternalServerError(w, err)
 	}
 
 	i.Compressor.ProcessSources(i.DB, params.ExportUUID)
@@ -102,7 +101,7 @@ func (i *Internal) PostUpload(w http.ResponseWriter, r *http.Request) {
 	i.Log.Info("received payload")
 	params := middleware.GetURLParams(r.Context())
 	if params == nil {
-		errors.InternalServerError(w, "unable to parse url params")
+		InternalServerError(w, "unable to parse url params")
 		return
 	}
 
@@ -110,11 +109,11 @@ func (i *Internal) PostUpload(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch err {
 		case models.ErrRecordNotFound:
-			errors.NotFoundError(w, fmt.Sprintf("record '%s' not found", params.ExportUUID))
+			NotFoundError(w, fmt.Sprintf("record '%s' not found", params.ExportUUID))
 			return
 		default:
 			i.Log.Errorw("error querying for payload entry", "error", err)
-			errors.InternalServerError(w, err)
+			InternalServerError(w, err)
 			return
 		}
 	}
@@ -122,28 +121,28 @@ func (i *Internal) PostUpload(w http.ResponseWriter, r *http.Request) {
 	_, source, err := payload.GetSource(params.ResourceUUID)
 	if err != nil {
 		i.Log.Errorf("failed to get source: %w", err)
-		errors.InternalServerError(w, err.Error())
+		InternalServerError(w, err.Error())
 		return
 	}
 
 	if source.Status == models.RSuccess || source.Status == models.RFailed {
 		// TODO: revisit this logic and response. Do we want to allow a re-write of an already zipped package?
 		w.WriteHeader(http.StatusGone)
-		errors.Logerr(w.Write([]byte("this resource has already been processed")))
+		Logerr(w.Write([]byte("this resource has already been processed")))
 		return
 	}
 
 	w.WriteHeader(http.StatusAccepted)
 
 	if err := i.Compressor.CreateObject(r.Context(), i.DB, r.Body, params, payload); err != nil {
-		errors.Logerr(w.Write([]byte(fmt.Sprintf("payload failed to upload: %v", err))))
+		Logerr(w.Write([]byte(fmt.Sprintf("payload failed to upload: %v", err))))
 	} else {
-		errors.Logerr(w.Write([]byte("payload delivered")))
+		Logerr(w.Write([]byte("payload delivered")))
 	}
 
 	if err := payload.SetSourceStatus(i.DB, params.ResourceUUID, models.RSuccess, nil); err != nil {
 		i.Log.Errorw("failed to set source status for successful export", "error", err)
-		errors.InternalServerError(w, err)
+		InternalServerError(w, err)
 	}
 
 	i.Compressor.ProcessSources(i.DB, params.ExportUUID)

--- a/exports/jsonerror_response.go
+++ b/exports/jsonerror_response.go
@@ -2,7 +2,7 @@
 Copyright 2022 Red Hat Inc.
 SPDX-License-Identifier: Apache-2.0
 */
-package errors
+package exports
 
 import (
 	"encoding/json"

--- a/middleware/internal.go
+++ b/middleware/internal.go
@@ -12,7 +12,6 @@ import (
 	chi "github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 
-	"github.com/redhatinsights/export-service-go/errors"
 	"github.com/redhatinsights/export-service-go/models"
 )
 
@@ -34,14 +33,14 @@ func URLParamsCtx(next http.Handler) http.Handler {
 		uid = chi.URLParam(r, "exportUUID")
 		exportUUID, err := uuid.Parse(uid)
 		if err != nil {
-			errors.BadRequestError(w, fmt.Sprintf("'%s' is not a valid export UUID", uid))
+			badRequestError(w, fmt.Sprintf("'%s' is not a valid export UUID", uid))
 			return
 		}
 
 		uid = chi.URLParam(r, "resourceUUID")
 		resourceUUID, err := uuid.Parse(uid)
 		if err != nil {
-			errors.BadRequestError(w, fmt.Sprintf("'%s' is not a valid resource UUID", uid))
+			badRequestError(w, fmt.Sprintf("'%s' is not a valid resource UUID", uid))
 			return
 		}
 

--- a/middleware/jsonerror_response_middleware.go
+++ b/middleware/jsonerror_response_middleware.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 Red Hat Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Error struct {
+	Msg  interface{} `json:"message"`
+	Code int         `json:"code"`
+}
+
+// JSONError writes the supplied error and status code to the ResponseWriter
+func jsonError(w http.ResponseWriter, err interface{}, code int) {
+	e := Error{Msg: err, Code: code}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(e)
+}
+
+// BadRequestError returns a 400 json response
+func badRequestError(w http.ResponseWriter, err interface{}) {
+	jsonError(w, err, http.StatusBadRequest)
+}

--- a/middleware/pagination.go
+++ b/middleware/pagination.go
@@ -10,8 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-
-	"github.com/redhatinsights/export-service-go/errors"
 )
 
 type paginationKey int
@@ -168,12 +166,12 @@ func PaginationCtx(next http.Handler) http.Handler {
 		if limit != "" {
 			lim, err := strconv.Atoi(limit)
 			if err != nil {
-				errors.BadRequestError(w, fmt.Errorf("invalid limit: %w", err))
+				badRequestError(w, fmt.Errorf("invalid limit: %w", err))
 				return
 			}
 
 			if lim < 0 {
-				errors.BadRequestError(w, fmt.Errorf("invalid limt: %d", lim))
+				badRequestError(w, fmt.Errorf("invalid limt: %d", lim))
 				return
 			}
 
@@ -184,12 +182,12 @@ func PaginationCtx(next http.Handler) http.Handler {
 		if offset != "" {
 			off, err := strconv.Atoi(offset)
 			if err != nil {
-				errors.BadRequestError(w, fmt.Errorf("invalid offset: %w", err))
+				badRequestError(w, fmt.Errorf("invalid offset: %w", err))
 				return
 			}
 
 			if off < 0 {
-				errors.BadRequestError(w, fmt.Errorf("invalid offset: %d", off))
+				badRequestError(w, fmt.Errorf("invalid offset: %d", off))
 				return
 			}
 
@@ -204,7 +202,7 @@ func PaginationCtx(next http.Handler) http.Handler {
 			case "created":
 				pagination.SortBy = "created_at"
 			default:
-				errors.BadRequestError(w, fmt.Errorf("sort does not match 'name', 'created', or 'expires': %s", sort))
+				badRequestError(w, fmt.Errorf("sort does not match 'name', 'created', or 'expires': %s", sort))
 				return
 			}
 		}
@@ -214,7 +212,7 @@ func PaginationCtx(next http.Handler) http.Handler {
 			switch dir {
 			case "asc", "desc":
 			default:
-				errors.BadRequestError(w, fmt.Errorf("dir does not match 'asc' or 'desc': %s", dir))
+				badRequestError(w, fmt.Errorf("dir does not match 'asc' or 'desc': %s", dir))
 				return
 			}
 

--- a/middleware/psks.go
+++ b/middleware/psks.go
@@ -6,8 +6,6 @@ package middleware
 
 import (
 	"net/http"
-
-	"github.com/redhatinsights/export-service-go/errors"
 )
 
 // SliceContainsString returns true if the specified target is present in the given slice.
@@ -27,12 +25,12 @@ func EnforcePSK(next http.Handler) http.Handler {
 		psk := r.Header["X-Rh-Exports-Psk"]
 
 		if len(psk) != 1 {
-			errors.BadRequestError(w, "missing x-rh-exports-psk header")
+			badRequestError(w, "missing x-rh-exports-psk header")
 			return
 		}
 
 		if !SliceContainsString(Cfg.Psks, psk[0]) {
-			errors.JSONError(w, "invalid x-rh-exports-psk header", http.StatusUnauthorized)
+			jsonError(w, "invalid x-rh-exports-psk header", http.StatusUnauthorized)
 			return
 		}
 

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -12,7 +12,6 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 
 	"github.com/redhatinsights/export-service-go/config"
-	"github.com/redhatinsights/export-service-go/errors"
 	"github.com/redhatinsights/export-service-go/logger"
 )
 
@@ -60,7 +59,7 @@ func EnforceUserIdentity(next http.Handler) http.Handler {
 		id := identity.Get(r.Context())
 
 		if id.Identity.Type != "User" {
-			errors.BadRequestError(w, fmt.Sprintf("'%s' is not a valid user type", id.Identity.Type))
+			badRequestError(w, fmt.Sprintf("'%s' is not a valid user type", id.Identity.Type))
 			return
 		}
 


### PR DESCRIPTION
## What?
https://issues.redhat.com/browse/RHCLOUD-21469
Move json errors out of the errors package and into the api area of the code

## Why?
To not have errors package if only the api area will be using it. 

## How?
Transferred file over to the exports package, as well as made a new file for middleware error since it was using badrequesterror. 

