### PR TITLE
Moving Errors to Exports

### DIFF
--- a/exports/jsonerror_response.go
+++ b/exports/jsonerror_response.go
@@ -2,7 +2,7 @@
 Copyright 2022 Red Hat Inc.
 SPDX-License-Identifier: Apache-2.0
 */
-package errors
+package exports
 
 import (
 	"encoding/json"

--- a/middleware/internal.go
+++ b/middleware/internal.go
@@ -11,8 +11,6 @@ import (
 
 	chi "github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
-
-	"github.com/redhatinsights/export-service-go/errors"
 )
 
 type internalKey int
@@ -41,14 +39,14 @@ func URLParamsCtx(next http.Handler) http.Handler {
 		uid = chi.URLParam(r, "exportUUID")
 		exportUUID, err := uuid.Parse(uid)
 		if err != nil {
-			errors.BadRequestError(w, fmt.Sprintf("'%s' is not a valid export UUID", uid))
+			BadRequestError(w, fmt.Sprintf("'%s' is not a valid export UUID", uid))
 			return
 		}
 
 		uid = chi.URLParam(r, "resourceUUID")
 		resourceUUID, err := uuid.Parse(uid)
 		if err != nil {
-			errors.BadRequestError(w, fmt.Sprintf("'%s' is not a valid resource UUID", uid))
+			BadRequestError(w, fmt.Sprintf("'%s' is not a valid resource UUID", uid))
 			return
 		}
 

--- a/middleware/jsonerror_response_middleware.go
+++ b/middleware/jsonerror_response_middleware.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 Red Hat Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Error struct {
+	Msg  interface{} `json:"message"`
+	Code int         `json:"code"`
+}
+
+// JSONError writes the supplied error and status code to the ResponseWriter
+func JSONError(w http.ResponseWriter, err interface{}, code int) {
+	e := Error{Msg: err, Code: code}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(e)
+}
+
+// BadRequestError returns a 400 json response
+func BadRequestError(w http.ResponseWriter, err interface{}) {
+	JSONError(w, err, http.StatusBadRequest)
+}

--- a/middleware/pagination.go
+++ b/middleware/pagination.go
@@ -10,8 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-
-	"github.com/redhatinsights/export-service-go/errors"
 )
 
 type paginationKey int
@@ -168,12 +166,12 @@ func PaginationCtx(next http.Handler) http.Handler {
 		if limit != "" {
 			lim, err := strconv.Atoi(limit)
 			if err != nil {
-				errors.BadRequestError(w, fmt.Errorf("invalid limit: %w", err))
+				BadRequestError(w, fmt.Errorf("invalid limit: %w", err))
 				return
 			}
 
 			if lim < 0 {
-				errors.BadRequestError(w, fmt.Errorf("invalid limt: %d", lim))
+				BadRequestError(w, fmt.Errorf("invalid limt: %d", lim))
 				return
 			}
 
@@ -184,12 +182,12 @@ func PaginationCtx(next http.Handler) http.Handler {
 		if offset != "" {
 			off, err := strconv.Atoi(offset)
 			if err != nil {
-				errors.BadRequestError(w, fmt.Errorf("invalid offset: %w", err))
+				BadRequestError(w, fmt.Errorf("invalid offset: %w", err))
 				return
 			}
 
 			if off < 0 {
-				errors.BadRequestError(w, fmt.Errorf("invalid offset: %d", off))
+				BadRequestError(w, fmt.Errorf("invalid offset: %d", off))
 				return
 			}
 
@@ -204,7 +202,7 @@ func PaginationCtx(next http.Handler) http.Handler {
 			case "created":
 				pagination.SortBy = "created_at"
 			default:
-				errors.BadRequestError(w, fmt.Errorf("sort does not match 'name', 'created', or 'expires': %s", sort))
+				BadRequestError(w, fmt.Errorf("sort does not match 'name', 'created', or 'expires': %s", sort))
 				return
 			}
 		}
@@ -214,7 +212,7 @@ func PaginationCtx(next http.Handler) http.Handler {
 			switch dir {
 			case "asc", "desc":
 			default:
-				errors.BadRequestError(w, fmt.Errorf("dir does not match 'asc' or 'desc': %s", dir))
+				BadRequestError(w, fmt.Errorf("dir does not match 'asc' or 'desc': %s", dir))
 				return
 			}
 

--- a/middleware/psks.go
+++ b/middleware/psks.go
@@ -6,8 +6,6 @@ package middleware
 
 import (
 	"net/http"
-
-	"github.com/redhatinsights/export-service-go/errors"
 )
 
 // SliceContainsString returns true if the specified target is present in the given slice.
@@ -27,12 +25,12 @@ func EnforcePSK(next http.Handler) http.Handler {
 		psk := r.Header["X-Rh-Exports-Psk"]
 
 		if len(psk) != 1 {
-			errors.BadRequestError(w, "missing x-rh-exports-psk header")
+			BadRequestError(w, "missing x-rh-exports-psk header")
 			return
 		}
 
 		if !SliceContainsString(Cfg.Psks, psk[0]) {
-			errors.JSONError(w, "invalid x-rh-exports-psk header", http.StatusUnauthorized)
+			JSONError(w, "invalid x-rh-exports-psk header", http.StatusUnauthorized)
 			return
 		}
 

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -12,7 +12,6 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 
 	"github.com/redhatinsights/export-service-go/config"
-	"github.com/redhatinsights/export-service-go/errors"
 	"github.com/redhatinsights/export-service-go/logger"
 )
 
@@ -60,7 +59,7 @@ func EnforceUserIdentity(next http.Handler) http.Handler {
 		id := identity.Get(r.Context())
 
 		if id.Identity.Type != "User" {
-			errors.BadRequestError(w, fmt.Sprintf("'%s' is not a valid user type", id.Identity.Type))
+			BadRequestError(w, fmt.Sprintf("'%s' is not a valid user type", id.Identity.Type))
 			return
 		}
 


### PR DESCRIPTION
## What?
https://issues.redhat.com/browse/RHCLOUD-21469
Move json errors out of the errors package and into the api area of the code

## Why?
To not have errors package if only the api area will be using it.

## How?
Transferred file over to the exports package, as well as made a new file for middleware error since it was using badrequesterror.
