### PR TITLE
Fix path to certfile in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -174,8 +174,15 @@ func init() {
 			Name:     cfg.Database.Name,
 			SSLCfg: dbSSLConfig{
 				SSLMode: cfg.Database.SslMode,
-				RdsCa:   cfg.Database.RdsCa,
 			},
+		}
+
+		if cfg.Database.RdsCa != nil {
+			pathToDBCertFile, err := cfg.RdsCa()
+			if err != nil {
+				panic(err)
+			}
+			config.DBConfig.SSLCfg.RdsCa = &pathToDBCertFile
 		}
 
 		config.KafkaConfig.Brokers = clowder.KafkaServers

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -134,7 +134,7 @@ objects:
 parameters:
   - name: APP_NAME
     description: Application common name
-    requred: true
+    required: true
     value: export-service
   - description: Cpu limit of service
     name: CPU_LIMIT


### PR DESCRIPTION
## What?
Fix the path to the certificate that is passed to the postgres connection string

## Why?
Fixes an error encountered in OpenShift where the connection string could not be parsed

## How?
Use the path to file, instead of the cert directly

## Anything Else?
Fixed a typo in `clowdapp.yml`

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
