### PR TITLE
[RHCLOUD-24854] Init race condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ sample-request-internal-error:
 	curl -X POST http://localhost:10010/app/export/v1/${EXPORT_ID}/${EXPORT_APPLICATION}/${EXPORT_RESOURCE}/error -H "x-rh-exports-psk: testing-a-psk" -H "Content-Type: application/json" -d @example_export_error.json
 
 make test:
-	ginkgo -r --race --randomize-all --randomize-suites
+	DEBUG=true ginkgo -r --race --randomize-all --randomize-suites
 
 test-sql:
 	go test ./... -tags=sql -count=1

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ sample-request-internal-error:
 	curl -X POST http://localhost:10010/app/export/v1/${EXPORT_ID}/${EXPORT_APPLICATION}/${EXPORT_RESOURCE}/error -H "x-rh-exports-psk: testing-a-psk" -H "Content-Type: application/json" -d @example_export_error.json
 
 make test:
-	DEBUG=true ginkgo -r --race --randomize-all --randomize-suites
+	ginkgo -r --race --randomize-all --randomize-suites
 
 test-sql:
 	go test ./... -tags=sql -count=1

--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -179,10 +179,12 @@ func startApiServer(cfg *config.ExportConfig, log *zap.SugaredLogger) {
 
 	kafkaRequestAppResources := exports.KafkaRequestApplicationResources(kafkaProducerMessagesChan)
 
+	s3Client := es3.NewS3Client(*cfg, log)
+
 	storageHandler := es3.Compressor{
 		Bucket: cfg.StorageConfig.Bucket,
 		Log:    log,
-		Client: *es3.Client,
+		Client: *s3Client,
 	}
 
 	external := exports.Export{

--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -54,9 +54,8 @@ func createPublicServer(cfg *config.ExportConfig, external exports.Export) *http
 	router.Route("/api/export/v1", func(r chi.Router) {
 		// add authentication middleware
 		r.Use(
-			emiddleware.InjectDebugUserIdentity, // InjectDebugUserIdentity injects a valid X-Rh-Identity header when the config.Debug is true.
-			identity.EnforceIdentity,            // EnforceIdentity extracts the X-Rh-Identity header and places the contents into the request context.
-			emiddleware.EnforceUserIdentity,     // EnforceUserIdentity extracts account_number, org_id, and username from the X-Rh-Identity context.
+			identity.EnforceIdentity,        // EnforceIdentity extracts the X-Rh-Identity header and places the contents into the request context.
+			emiddleware.EnforceUserIdentity, // EnforceUserIdentity extracts account_number, org_id, and username from the X-Rh-Identity context.
 		)
 
 		// add external routes

--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -184,12 +184,13 @@ func startApiServer(cfg *config.ExportConfig, log *zap.SugaredLogger) {
 		Bucket: cfg.StorageConfig.Bucket,
 		Log:    log,
 		Client: *s3Client,
+		Cfg:    *cfg,
 	}
 
 	external := exports.Export{
 		Bucket:              cfg.StorageConfig.Bucket,
 		StorageHandler:      &storageHandler,
-		DB:                  &models.ExportDB{DB: DB},
+		DB:                  &models.ExportDB{DB: DB, Cfg: cfg},
 		RequestAppResources: kafkaRequestAppResources,
 		Log:                 log,
 	}
@@ -198,7 +199,7 @@ func startApiServer(cfg *config.ExportConfig, log *zap.SugaredLogger) {
 	internal := exports.Internal{
 		Cfg:        cfg,
 		Compressor: &storageHandler,
-		DB:         &models.ExportDB{DB: DB},
+		DB:         &models.ExportDB{DB: DB, Cfg: cfg},
 		Log:        log,
 	}
 	psrv := createPrivateServer(cfg, internal)

--- a/cmd/export-service/main.go
+++ b/cmd/export-service/main.go
@@ -72,7 +72,7 @@ func createRootCommand(cfg *config.ExportConfig, log *zap.SugaredLogger) *cobra.
 }
 
 func main() {
-	cfg := config.ExportCfg
+	cfg := config.Get()
 	log := logger.Log
 
 	cmd := createRootCommand(cfg, log)

--- a/cmd/export-service/main.go
+++ b/cmd/export-service/main.go
@@ -73,7 +73,7 @@ func createRootCommand(cfg *config.ExportConfig, log *zap.SugaredLogger) *cobra.
 
 func main() {
 	cfg := config.Get()
-	log := logger.Log
+	log := logger.Get()
 
 	cmd := createRootCommand(cfg, log)
 	if err := cmd.Execute(); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 	"github.com/spf13/viper"
@@ -76,146 +77,149 @@ type storageConfig struct {
 	UseSSL    bool
 }
 
+var config *ExportConfig
+var doOnce sync.Once
+
 // initialize the configuration for service
 func Get() *ExportConfig {
-	var config *ExportConfig
+	doOnce.Do(func() {
+		options := viper.New()
+		options.SetDefault("PublicPort", 8000)
+		options.SetDefault("MetricsPort", 9000)
+		options.SetDefault("PrivatePort", 10000)
+		options.SetDefault("LogLevel", "INFO")
+		options.SetDefault("Debug", false)
+		options.SetDefault("OpenAPIFilePath", "./static/spec/openapi.json")
+		options.SetDefault("psks", strings.Split(os.Getenv("EXPORTS_PSKS"), ","))
+		options.SetDefault("Export_Expiriy_Days", 7)
 
-	options := viper.New()
-	options.SetDefault("PublicPort", 8000)
-	options.SetDefault("MetricsPort", 9000)
-	options.SetDefault("PrivatePort", 10000)
-	options.SetDefault("LogLevel", "INFO")
-	options.SetDefault("Debug", false)
-	options.SetDefault("OpenAPIFilePath", "./static/spec/openapi.json")
-	options.SetDefault("psks", strings.Split(os.Getenv("EXPORTS_PSKS"), ","))
-	options.SetDefault("Export_Expiriy_Days", 7)
+		// DB defaults
+		options.SetDefault("PGSQL_USER", "postgres")
+		options.SetDefault("PGSQL_PASSWORD", "postgres")
+		options.SetDefault("PGSQL_HOSTNAME", "localhost")
+		options.SetDefault("PGSQL_PORT", "15433")
+		options.SetDefault("PGSQL_DATABASE", "postgres")
 
-	// DB defaults
-	options.SetDefault("PGSQL_USER", "postgres")
-	options.SetDefault("PGSQL_PASSWORD", "postgres")
-	options.SetDefault("PGSQL_HOSTNAME", "localhost")
-	options.SetDefault("PGSQL_PORT", "15433")
-	options.SetDefault("PGSQL_DATABASE", "postgres")
+		// Minio defaults
+		options.SetDefault("MINIO_HOST", "localhost")
+		options.SetDefault("MINIO_PORT", "9099")
+		options.SetDefault("MINIO_SSL", false)
 
-	// Minio defaults
-	options.SetDefault("MINIO_HOST", "localhost")
-	options.SetDefault("MINIO_PORT", "9099")
-	options.SetDefault("MINIO_SSL", false)
+		// Kafka defaults
+		options.SetDefault("KafakAnnounceTopic", ExportTopic)
+		options.SetDefault("KafkaBrokers", strings.Split(os.Getenv("KAFKA_BROKERS"), ","))
+		options.SetDefault("KafkaGroupID", "export")
 
-	// Kafka defaults
-	options.SetDefault("KafakAnnounceTopic", ExportTopic)
-	options.SetDefault("KafkaBrokers", strings.Split(os.Getenv("KAFKA_BROKERS"), ","))
-	options.SetDefault("KafkaGroupID", "export")
+		options.AutomaticEnv()
 
-	options.AutomaticEnv()
+		if options.GetBool("Debug") {
+			options.Set("LogLevel", "DEBUG")
+		}
 
-	if options.GetBool("Debug") {
-		options.Set("LogLevel", "DEBUG")
-	}
+		kubenv := viper.New()
+		kubenv.AutomaticEnv()
 
-	kubenv := viper.New()
-	kubenv.AutomaticEnv()
-
-	config = &ExportConfig{
-		Hostname:         kubenv.GetString("Hostname"),
-		PublicPort:       options.GetInt("PublicPort"),
-		MetricsPort:      options.GetInt("MetricsPort"),
-		PrivatePort:      options.GetInt("PrivatePort"),
-		Debug:            options.GetBool("Debug"),
-		LogLevel:         options.GetString("LogLevel"),
-		OpenAPIFilePath:  options.GetString("OpenAPIFilePath"),
-		Psks:             options.GetStringSlice("psks"),
-		ExportExpiryDays: options.GetInt("Export_Expiriy_Days"),
-	}
-
-	config.DBConfig = dbConfig{
-		User:     options.GetString("PGSQL_USER"),
-		Password: options.GetString("PGSQL_PASSWORD"),
-		Hostname: options.GetString("PGSQL_HOSTNAME"),
-		Port:     options.GetString("PGSQL_PORT"),
-		Name:     options.GetString("PGSQL_DATABASE"),
-		SSLCfg: dbSSLConfig{
-			SSLMode: "disable",
-		},
-	}
-
-	config.StorageConfig = storageConfig{
-		Bucket:    "exports-bucket",
-		Endpoint:  buildBaseHttpUrl(options.GetBool("MINIO_SSL"), options.GetString("MINIO_HOST"), options.GetInt("MINIO_PORT")),
-		AccessKey: options.GetString("AWS_ACCESS_KEY"),
-		SecretKey: options.GetString("AWS_SECRET_ACCESS_KEY"),
-		UseSSL:    options.GetBool("MINIO_SSL"),
-	}
-
-	config.KafkaConfig = kafkaConfig{
-		Brokers:      options.GetStringSlice("KafkaBrokers"),
-		GroupID:      options.GetString("KafkaGroupID"),
-		ExportsTopic: options.GetString("KafakAnnounceTopic"),
-	}
-
-	if clowder.IsClowderEnabled() {
-		cfg := clowder.LoadedConfig
-
-		config.PublicPort = *cfg.PublicPort
-		config.MetricsPort = cfg.MetricsPort
-		config.PrivatePort = *cfg.PrivatePort
-
-		exportBucket := options.GetString("EXPORT_SERVICE_BUCKET")
-		exportBucketInfo := clowder.ObjectBuckets[exportBucket]
-
-		rdsCaPath, err := getRdsCaPath(cfg)
-		if err != nil {
-			panic("RDS CA failed to write: " + err.Error())
+		config = &ExportConfig{
+			Hostname:         kubenv.GetString("Hostname"),
+			PublicPort:       options.GetInt("PublicPort"),
+			MetricsPort:      options.GetInt("MetricsPort"),
+			PrivatePort:      options.GetInt("PrivatePort"),
+			Debug:            options.GetBool("Debug"),
+			LogLevel:         options.GetString("LogLevel"),
+			OpenAPIFilePath:  options.GetString("OpenAPIFilePath"),
+			Psks:             options.GetStringSlice("psks"),
+			ExportExpiryDays: options.GetInt("Export_Expiriy_Days"),
 		}
 
 		config.DBConfig = dbConfig{
-			User:     cfg.Database.Username,
-			Password: cfg.Database.Password,
-			Hostname: cfg.Database.Hostname,
-			Port:     fmt.Sprint(cfg.Database.Port),
-			Name:     cfg.Database.Name,
+			User:     options.GetString("PGSQL_USER"),
+			Password: options.GetString("PGSQL_PASSWORD"),
+			Hostname: options.GetString("PGSQL_HOSTNAME"),
+			Port:     options.GetString("PGSQL_PORT"),
+			Name:     options.GetString("PGSQL_DATABASE"),
 			SSLCfg: dbSSLConfig{
-				SSLMode: cfg.Database.SslMode,
-				RdsCa:   rdsCaPath,
+				SSLMode: "disable",
 			},
 		}
 
-		config.KafkaConfig.Brokers = clowder.KafkaServers
-		broker := cfg.Kafka.Brokers[0]
-		if broker.Authtype != nil {
-			caPath, err := cfg.KafkaCa(broker)
-			if err != nil {
-				panic("Kafka CA failed to write")
-			}
-			securityProtocol := "sasl_ssl"
-			if broker.SecurityProtocol != nil {
-				securityProtocol = *broker.SecurityProtocol
-			}
-			config.KafkaConfig.SSLConfig = kafkaSSLConfig{
-				Username:      *broker.Sasl.Username,
-				Password:      *broker.Sasl.Password,
-				SASLMechanism: *broker.Sasl.SaslMechanism,
-				Protocol:      securityProtocol,
-				CA:            caPath,
-			}
-		}
-
-		config.Logging = &loggingConfig{
-			AccessKeyID:     cfg.Logging.Cloudwatch.AccessKeyId,
-			SecretAccessKey: cfg.Logging.Cloudwatch.SecretAccessKey,
-			LogGroup:        cfg.Logging.Cloudwatch.LogGroup,
-			Region:          cfg.Logging.Cloudwatch.Region,
-		}
-
-		bucket := cfg.ObjectStore.Buckets[0]
 		config.StorageConfig = storageConfig{
-			Bucket:    exportBucketInfo.RequestedName,
-			Endpoint:  buildBaseHttpUrl(cfg.ObjectStore.Tls, cfg.ObjectStore.Hostname, cfg.ObjectStore.Port),
-			AccessKey: *bucket.AccessKey,
-			SecretKey: *bucket.SecretKey,
-			UseSSL:    cfg.ObjectStore.Tls,
+			Bucket:    "exports-bucket",
+			Endpoint:  buildBaseHttpUrl(options.GetBool("MINIO_SSL"), options.GetString("MINIO_HOST"), options.GetInt("MINIO_PORT")),
+			AccessKey: options.GetString("AWS_ACCESS_KEY"),
+			SecretKey: options.GetString("AWS_SECRET_ACCESS_KEY"),
+			UseSSL:    options.GetBool("MINIO_SSL"),
 		}
-	}
+
+		config.KafkaConfig = kafkaConfig{
+			Brokers:      options.GetStringSlice("KafkaBrokers"),
+			GroupID:      options.GetString("KafkaGroupID"),
+			ExportsTopic: options.GetString("KafakAnnounceTopic"),
+		}
+
+		if clowder.IsClowderEnabled() {
+			cfg := clowder.LoadedConfig
+
+			config.PublicPort = *cfg.PublicPort
+			config.MetricsPort = cfg.MetricsPort
+			config.PrivatePort = *cfg.PrivatePort
+
+			exportBucket := options.GetString("EXPORT_SERVICE_BUCKET")
+			exportBucketInfo := clowder.ObjectBuckets[exportBucket]
+
+			rdsCaPath, err := getRdsCaPath(cfg)
+			if err != nil {
+				panic("RDS CA failed to write: " + err.Error())
+			}
+
+			config.DBConfig = dbConfig{
+				User:     cfg.Database.Username,
+				Password: cfg.Database.Password,
+				Hostname: cfg.Database.Hostname,
+				Port:     fmt.Sprint(cfg.Database.Port),
+				Name:     cfg.Database.Name,
+				SSLCfg: dbSSLConfig{
+					SSLMode: cfg.Database.SslMode,
+					RdsCa:   rdsCaPath,
+				},
+			}
+
+			config.KafkaConfig.Brokers = clowder.KafkaServers
+			broker := cfg.Kafka.Brokers[0]
+			if broker.Authtype != nil {
+				caPath, err := cfg.KafkaCa(broker)
+				if err != nil {
+					panic("Kafka CA failed to write")
+				}
+				securityProtocol := "sasl_ssl"
+				if broker.SecurityProtocol != nil {
+					securityProtocol = *broker.SecurityProtocol
+				}
+				config.KafkaConfig.SSLConfig = kafkaSSLConfig{
+					Username:      *broker.Sasl.Username,
+					Password:      *broker.Sasl.Password,
+					SASLMechanism: *broker.Sasl.SaslMechanism,
+					Protocol:      securityProtocol,
+					CA:            caPath,
+				}
+			}
+
+			config.Logging = &loggingConfig{
+				AccessKeyID:     cfg.Logging.Cloudwatch.AccessKeyId,
+				SecretAccessKey: cfg.Logging.Cloudwatch.SecretAccessKey,
+				LogGroup:        cfg.Logging.Cloudwatch.LogGroup,
+				Region:          cfg.Logging.Cloudwatch.Region,
+			}
+
+			bucket := cfg.ObjectStore.Buckets[0]
+			config.StorageConfig = storageConfig{
+				Bucket:    exportBucketInfo.RequestedName,
+				Endpoint:  buildBaseHttpUrl(cfg.ObjectStore.Tls, cfg.ObjectStore.Hostname, cfg.ObjectStore.Port),
+				AccessKey: *bucket.AccessKey,
+				SecretKey: *bucket.SecretKey,
+				UseSSL:    cfg.ObjectStore.Tls,
+			}
+		}
+	})
 
 	return config
 }

--- a/exports/export_suite_test.go
+++ b/exports/export_suite_test.go
@@ -50,7 +50,7 @@ func CreateTestDB(cfg config.ExportConfig) (*embeddedpostgres.EmbeddedPostgres, 
 		return nil, nil, err
 	}
 
-	err = db_utils.PerformDbMigration(dbConn, logger.Log, "file://../db/migrations", "up")
+	err = db_utils.PerformDbMigration(dbConn, logger.Get(), "file://../db/migrations", "up")
 	if err != nil {
 		fmt.Println("Database migration failed: ", err)
 		return nil, nil, err

--- a/exports/export_suite_test.go
+++ b/exports/export_suite_test.go
@@ -61,7 +61,7 @@ func CreateTestDB(cfg config.ExportConfig) (*embeddedpostgres.EmbeddedPostgres, 
 }
 
 var _ = BeforeSuite(func() {
-	cfg := config.ExportCfg
+	cfg := config.Get()
 
 	var err error
 	testDB, testGormDB, err = CreateTestDB(*cfg)

--- a/exports/exports_test.go
+++ b/exports/exports_test.go
@@ -41,7 +41,7 @@ func createExportRequest(name, format, expires, sources string) *http.Request {
 }
 
 var _ = Describe("The public API", func() {
-	cfg := config.ExportCfg
+	cfg := config.Get()
 	cfg.Debug = true
 
 	DescribeTable("can create a new export request", func(name, format, expires, sources, expectedBody string, expectedStatus int) {

--- a/exports/exports_test.go
+++ b/exports/exports_test.go
@@ -17,13 +17,18 @@ import (
 
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 
-	"github.com/redhatinsights/export-service-go/config"
 	"github.com/redhatinsights/export-service-go/exports"
 	"github.com/redhatinsights/export-service-go/logger"
 	emiddleware "github.com/redhatinsights/export-service-go/middleware"
 	"github.com/redhatinsights/export-service-go/models"
 	es3 "github.com/redhatinsights/export-service-go/s3"
 )
+
+const debugHeader string = "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEwMDAxIiwib3JnX2lkIjoiMTAwMDAwMDEiLCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMDAwMDAwMSJ9LCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ1c2VyX2RldiJ9fX0K"
+
+func AddDebugUserIdentity(req *http.Request) {
+	req.Header.Add("x-rh-identity", debugHeader)
+}
 
 func generateExportRequestBody(name, format, expires, sources string) (exportRequest []byte) {
 	if expires != "" {
@@ -41,9 +46,6 @@ func createExportRequest(name, format, expires, sources string) *http.Request {
 }
 
 var _ = Describe("The public API", func() {
-	cfg := config.Get()
-	cfg.Debug = true
-
 	DescribeTable("can create a new export request", func(name, format, expires, sources, expectedBody string, expectedStatus int) {
 		router := setupTest(mockReqeustApplicationResouces)
 
@@ -51,6 +53,7 @@ var _ = Describe("The public API", func() {
 
 		rr := httptest.NewRecorder()
 
+		AddDebugUserIdentity(req)
 		router.ServeHTTP(rr, req)
 		Expect(rr.Code).To(Equal(expectedStatus))
 		Expect(rr.Body.String()).To(ContainSubstring(expectedBody))
@@ -75,6 +78,7 @@ var _ = Describe("The public API", func() {
 				`{"application":"exampleApp", "resource":"exampleResource"}`,
 			)
 
+			AddDebugUserIdentity(req)
 			router.ServeHTTP(rr, req)
 			Expect(rr.Code).To(Equal(http.StatusAccepted))
 		}
@@ -85,6 +89,7 @@ var _ = Describe("The public API", func() {
 
 		rr = httptest.NewRecorder()
 
+		AddDebugUserIdentity(req)
 		router.ServeHTTP(rr, req)
 		Expect(rr.Code).To(Equal(http.StatusOK))
 		Expect(rr.Body.String()).To(ContainSubstring("Test Export Request 1"))
@@ -101,6 +106,7 @@ var _ = Describe("The public API", func() {
 
 		rr := httptest.NewRecorder()
 
+		AddDebugUserIdentity(req)
 		router.ServeHTTP(rr, req)
 		Expect(rr.Code).To(Equal(expectedStatus))
 		Expect(rr.Body.String()).To(ContainSubstring(expectedBody))
@@ -128,6 +134,7 @@ var _ = Describe("The public API", func() {
 
 			Expect(err).ShouldNot(HaveOccurred())
 
+			AddDebugUserIdentity(req)
 			router.ServeHTTP(rr, req)
 
 			Expect(rr.Code).To(Equal(http.StatusOK))
@@ -151,6 +158,7 @@ var _ = Describe("The public API", func() {
 
 			Expect(err).ShouldNot(HaveOccurred())
 
+			AddDebugUserIdentity(req)
 			router.ServeHTTP(rr, req)
 
 			Expect(rr.Code).To(Equal(http.StatusOK))
@@ -173,6 +181,7 @@ var _ = Describe("The public API", func() {
 
 			Expect(err).ShouldNot(HaveOccurred())
 
+			AddDebugUserIdentity(req)
 			router.ServeHTTP(rr, req)
 
 			Expect(rr.Code).To(Equal(http.StatusOK))
@@ -195,6 +204,7 @@ var _ = Describe("The public API", func() {
 
 			Expect(err).ShouldNot(HaveOccurred())
 
+			AddDebugUserIdentity(req)
 			router.ServeHTTP(rr, req)
 
 			Expect(rr.Code).To(Equal(http.StatusOK))
@@ -221,6 +231,7 @@ var _ = Describe("The public API", func() {
 
 			rr := httptest.NewRecorder()
 
+			AddDebugUserIdentity(req)
 			router.ServeHTTP(rr, req)
 
 			Expect(rr.Code).To(Equal(http.StatusAccepted))
@@ -232,6 +243,7 @@ var _ = Describe("The public API", func() {
 		req.Header.Set("Content-Type", "application/json")
 		Expect(err).ShouldNot(HaveOccurred())
 
+		AddDebugUserIdentity(req)
 		router.ServeHTTP(rr, req)
 
 		Expect(rr.Code).To(Equal(http.StatusOK))
@@ -261,6 +273,7 @@ var _ = Describe("The public API", func() {
 		req.Header.Set("Content-Type", "application/json")
 		Expect(err).ShouldNot(HaveOccurred())
 
+		AddDebugUserIdentity(req)
 		router.ServeHTTP(rr, req)
 
 		Expect(rr.Code).To(Equal(http.StatusOK))
@@ -283,6 +296,7 @@ var _ = Describe("The public API", func() {
 
 			rr := httptest.NewRecorder()
 
+			AddDebugUserIdentity(req)
 			router.ServeHTTP(rr, req)
 
 			Expect(rr.Code).To(Equal(http.StatusAccepted))
@@ -305,6 +319,7 @@ var _ = Describe("The public API", func() {
 
 		Expect(err).ShouldNot(HaveOccurred())
 
+		AddDebugUserIdentity(req)
 		router.ServeHTTP(rr, req)
 
 		Expect(rr.Code).To(Equal(http.StatusOK))
@@ -386,6 +401,7 @@ var _ = Describe("The public API", func() {
 			"",
 			`{"application":"exampleApp", "resource":"exampleResource"}`,
 		)
+		AddDebugUserIdentity(req)
 		router.ServeHTTP(rr, req)
 		Expect(rr.Code).To(Equal(http.StatusAccepted))
 
@@ -403,6 +419,7 @@ var _ = Describe("The public API", func() {
 
 		rr = httptest.NewRecorder()
 
+		AddDebugUserIdentity(req)
 		router.ServeHTTP(rr, req)
 		Expect(rr.Code).To(Equal(http.StatusOK))
 		Expect(rr.Body.String()).To(ContainSubstring(`"status":"pending"`))
@@ -426,6 +443,7 @@ var _ = Describe("The public API", func() {
 			`{"application":"exampleApp", "resource":"exampleResource"}`,
 		)
 
+		AddDebugUserIdentity(req)
 		router.ServeHTTP(rr, req)
 
 		Expect(rr.Code).To(Equal(http.StatusAccepted))
@@ -445,6 +463,7 @@ var _ = Describe("The public API", func() {
 			"",
 			`{"application":"exampleApp", "resource":"exampleResource"}`,
 		)
+		AddDebugUserIdentity(req)
 		router.ServeHTTP(rr, req)
 		Expect(rr.Code).To(Equal(http.StatusAccepted))
 
@@ -459,6 +478,7 @@ var _ = Describe("The public API", func() {
 		req.Header.Set("Content-Type", "application/json")
 		Expect(err).ShouldNot(HaveOccurred())
 
+		AddDebugUserIdentity(req)
 		router.ServeHTTP(rr, req)
 		Expect(rr.Code).To(Equal(http.StatusAccepted))
 
@@ -468,6 +488,7 @@ var _ = Describe("The public API", func() {
 		req.Header.Set("Content-Type", "application/json")
 		Expect(err).ShouldNot(HaveOccurred())
 
+		AddDebugUserIdentity(req)
 		router.ServeHTTP(rr, req)
 		Expect(rr.Code).To(Equal(http.StatusNotFound))
 		Expect(rr.Body.String()).To(ContainSubstring("not found"))
@@ -494,7 +515,6 @@ func setupTest(requestAppResources exports.RequestApplicationResources) chi.Rout
 
 	router = chi.NewRouter()
 	router.Use(
-		emiddleware.InjectDebugUserIdentity,
 		identity.EnforceIdentity,
 		emiddleware.EnforceUserIdentity,
 	)
@@ -527,6 +547,7 @@ func populateTestData() chi.Router {
 
 		rr := httptest.NewRecorder()
 
+		AddDebugUserIdentity(req)
 		router.ServeHTTP(rr, req)
 	}
 

--- a/exports/exports_test.go
+++ b/exports/exports_test.go
@@ -502,6 +502,7 @@ func mockReqeustApplicationResouces(ctx context.Context, log *zap.SugaredLogger,
 func setupTest(requestAppResources exports.RequestApplicationResources) chi.Router {
 	var exportHandler *exports.Export
 	var router *chi.Mux
+	log := logger.Get()
 
 	fmt.Println("STARTING TEST")
 
@@ -510,7 +511,7 @@ func setupTest(requestAppResources exports.RequestApplicationResources) chi.Rout
 		StorageHandler:      &es3.MockStorageHandler{},
 		DB:                  &models.ExportDB{DB: testGormDB},
 		RequestAppResources: requestAppResources,
-		Log:                 logger.Log,
+		Log:                 log,
 	}
 
 	router = chi.NewRouter()

--- a/exports/exports_test.go
+++ b/exports/exports_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 
+	"github.com/redhatinsights/export-service-go/config"
 	"github.com/redhatinsights/export-service-go/exports"
 	"github.com/redhatinsights/export-service-go/logger"
 	emiddleware "github.com/redhatinsights/export-service-go/middleware"
@@ -502,6 +503,7 @@ func mockReqeustApplicationResouces(ctx context.Context, log *zap.SugaredLogger,
 func setupTest(requestAppResources exports.RequestApplicationResources) chi.Router {
 	var exportHandler *exports.Export
 	var router *chi.Mux
+	config := config.Get()
 	log := logger.Get()
 
 	fmt.Println("STARTING TEST")
@@ -509,7 +511,7 @@ func setupTest(requestAppResources exports.RequestApplicationResources) chi.Rout
 	exportHandler = &exports.Export{
 		Bucket:              "cfg.StorageConfig.Bucket",
 		StorageHandler:      &es3.MockStorageHandler{},
-		DB:                  &models.ExportDB{DB: testGormDB},
+		DB:                  &models.ExportDB{DB: testGormDB, Cfg: config},
 		RequestAppResources: requestAppResources,
 		Log:                 log,
 	}

--- a/exports/internal_test.go
+++ b/exports/internal_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 var _ = Context("Set up internal handler", func() {
-	cfg := config.ExportCfg
+	cfg := config.Get()
 	cfg.Debug = true
 
 	var internalHandler *exports.Internal

--- a/exports/internal_test.go
+++ b/exports/internal_test.go
@@ -24,7 +24,6 @@ import (
 
 var _ = Context("Set up internal handler", func() {
 	cfg := config.Get()
-	cfg.Debug = true
 
 	var internalHandler *exports.Internal
 	var router *chi.Mux
@@ -50,7 +49,6 @@ var _ = Context("Set up internal handler", func() {
 
 		router = chi.NewRouter()
 		router.Use(
-			emiddleware.InjectDebugUserIdentity,
 			identity.EnforceIdentity,
 			emiddleware.EnforceUserIdentity,
 		)
@@ -79,6 +77,7 @@ var _ = Context("Set up internal handler", func() {
 			rr := httptest.NewRecorder()
 
 			req := createExportRequest("testRequest", "json", "", `{"application":"exampleApp", "resource":"exampleResource"}`)
+			AddDebugUserIdentity(req)
 			router.ServeHTTP(rr, req)
 			Expect(rr.Code).To(Equal(http.StatusAccepted))
 
@@ -96,12 +95,14 @@ var _ = Context("Set up internal handler", func() {
 			rr = httptest.NewRecorder()
 			dummyBody := `{"data": "dummy data"}`
 			req = httptest.NewRequest("POST", fmt.Sprintf("/app/export/v1/upload/%s/exampleApp/%s", exportUUID, resourceUUID), bytes.NewBuffer([]byte(dummyBody)))
+			AddDebugUserIdentity(req)
 			router.ServeHTTP(rr, req)
 			Expect(rr.Code).To(Equal(http.StatusAccepted))
 
 			// check that the status of the export is now 'complete'
 			rr = httptest.NewRecorder()
 			req = httptest.NewRequest("GET", fmt.Sprintf("/api/export/v1/exports/%s/status", exportUUID), nil)
+			AddDebugUserIdentity(req)
 			router.ServeHTTP(rr, req)
 			Expect(rr.Code).To(Equal(http.StatusOK))
 
@@ -117,6 +118,7 @@ var _ = Context("Set up internal handler", func() {
 			rr := httptest.NewRecorder()
 
 			req := createExportRequest("testRequest", "json", "2023-01-01T00:00:00Z", `{"application":"exampleApp", "resource":"exampleResource"}`)
+			AddDebugUserIdentity(req)
 			router.ServeHTTP(rr, req)
 			Expect(rr.Code).To(Equal(http.StatusAccepted))
 
@@ -135,12 +137,14 @@ var _ = Context("Set up internal handler", func() {
 			rr = httptest.NewRecorder()
 			dummyBody := `{"data": "dummy data"}`
 			req = httptest.NewRequest("POST", fmt.Sprintf("/app/export/v1/error/%s/exampleApp/%s", exportUUID, resourceUUID), bytes.NewBuffer([]byte(dummyBody)))
+			AddDebugUserIdentity(req)
 			router.ServeHTTP(rr, req)
 			Expect(rr.Code).To(Equal(http.StatusAccepted))
 
 			// check that the status of the export is now 'complete'
 			rr = httptest.NewRecorder()
 			req = httptest.NewRequest("GET", fmt.Sprintf("/api/export/v1/exports/%s/status", exportUUID), nil)
+			AddDebugUserIdentity(req)
 			router.ServeHTTP(rr, req)
 			Expect(rr.Code).To(Equal(http.StatusOK))
 			var exportResponse2 map[string]interface{}

--- a/exports/internal_test.go
+++ b/exports/internal_test.go
@@ -24,16 +24,18 @@ import (
 
 var _ = Context("Set up internal handler", func() {
 	cfg := config.Get()
+	log := logger.Get()
 
 	var internalHandler *exports.Internal
 	var router *chi.Mux
 
 	BeforeEach(func() {
+
 		internalHandler = &exports.Internal{
 			Cfg:        cfg,
 			Compressor: &es3.MockStorageHandler{},
 			DB:         &models.ExportDB{DB: testGormDB},
-			Log:        logger.Log,
+			Log:        log,
 		}
 
 		mockKafkaCall := func(ctx context.Context, log *zap.SugaredLogger, identity string, payload models.ExportPayload) {
@@ -44,7 +46,7 @@ var _ = Context("Set up internal handler", func() {
 			StorageHandler:      &es3.MockStorageHandler{},
 			DB:                  &models.ExportDB{DB: testGormDB},
 			RequestAppResources: mockKafkaCall,
-			Log:                 logger.Log,
+			Log:                 log,
 		}
 
 		router = chi.NewRouter()

--- a/exports/internal_test.go
+++ b/exports/internal_test.go
@@ -34,7 +34,7 @@ var _ = Context("Set up internal handler", func() {
 		internalHandler = &exports.Internal{
 			Cfg:        cfg,
 			Compressor: &es3.MockStorageHandler{},
-			DB:         &models.ExportDB{DB: testGormDB},
+			DB:         &models.ExportDB{DB: testGormDB, Cfg: cfg},
 			Log:        log,
 		}
 
@@ -44,7 +44,7 @@ var _ = Context("Set up internal handler", func() {
 		exportHandler := &exports.Export{
 			Bucket:              "cfg.StorageConfig.Bucket",
 			StorageHandler:      &es3.MockStorageHandler{},
-			DB:                  &models.ExportDB{DB: testGormDB},
+			DB:                  &models.ExportDB{DB: testGormDB, Cfg: cfg},
 			RequestAppResources: mockKafkaCall,
 			Log:                 log,
 		}

--- a/exports/jsonerror_response.go
+++ b/exports/jsonerror_response.go
@@ -11,7 +11,7 @@ import (
 	"github.com/redhatinsights/export-service-go/logger"
 )
 
-var log = logger.Log
+var log = logger.Get()
 
 type Error struct {
 	Msg  interface{} `json:"message"`

--- a/exports/request_resources.go
+++ b/exports/request_resources.go
@@ -10,6 +10,7 @@ import (
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"go.uber.org/zap"
 
+	"github.com/redhatinsights/export-service-go/config"
 	ekafka "github.com/redhatinsights/export-service-go/kafka"
 	"github.com/redhatinsights/export-service-go/models"
 )
@@ -17,6 +18,7 @@ import (
 type RequestApplicationResources func(ctx context.Context, log *zap.SugaredLogger, identity string, payload models.ExportPayload)
 
 func KafkaRequestApplicationResources(kafkaChan chan *kafka.Message) RequestApplicationResources {
+	var exportsTopic = config.Get().KafkaConfig.ExportsTopic
 	// sendPayload converts the individual sources of a payload into
 	// kafka messages which are then sent to the producer through the
 	// `messagesChan`
@@ -45,7 +47,7 @@ func KafkaRequestApplicationResources(kafkaChan chan *kafka.Message) RequestAppl
 					IDHeader:     identity,
 				}
 
-				msg, err := kpayload.ToMessage(headers)
+				msg, err := kpayload.ToMessage(headers, exportsTopic)
 				if err != nil {
 					log.Errorw("failed to create kafka message", "error", err)
 					// FIXME:

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	cfg = config.ExportCfg
+	cfg = config.Get()
 	log = logger.Log
 
 	messagesPublished = prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	cfg = config.Get()
-	log = logger.Log
+	log = logger.Get()
 
 	messagesPublished = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "ingress_kafka_produced",

--- a/kafka/types.go
+++ b/kafka/types.go
@@ -5,11 +5,7 @@ import (
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/google/uuid"
-
-	"github.com/redhatinsights/export-service-go/config"
 )
-
-var kcfg = config.Get().KafkaConfig
 
 type KafkaHeader struct {
 	Application string `json:"application"`
@@ -43,7 +39,7 @@ type KafkaMessage struct {
 
 // ToMessage converts the KafkaMessage struct to a confluent kafka.Message
 // ready to be sent through the kafka producer
-func (km KafkaMessage) ToMessage(header KafkaHeader) (*kafka.Message, error) {
+func (km KafkaMessage) ToMessage(header KafkaHeader, topic string) (*kafka.Message, error) {
 	val, err := json.Marshal(km)
 	if err != nil {
 		return nil, err
@@ -51,7 +47,7 @@ func (km KafkaMessage) ToMessage(header KafkaHeader) (*kafka.Message, error) {
 	return &kafka.Message{
 		Headers: header.ToHeader(),
 		TopicPartition: kafka.TopicPartition{
-			Topic:     &kcfg.ExportsTopic,
+			Topic:     &topic,
 			Partition: kafka.PartitionAny,
 		},
 		Value: []byte(val),

--- a/kafka/types.go
+++ b/kafka/types.go
@@ -9,7 +9,7 @@ import (
 	"github.com/redhatinsights/export-service-go/config"
 )
 
-var kcfg = config.ExportCfg.KafkaConfig
+var kcfg = config.Get().KafkaConfig
 
 type KafkaHeader struct {
 	Application string `json:"application"`

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -25,54 +25,57 @@ var Log *zap.SugaredLogger
 
 var cfg = config.Get()
 
-func init() {
-	tmpLogger := zap.NewExample()
-	loggerConfig := zap.NewProductionConfig()
-	loggerConfig.EncoderConfig.TimeKey = "@timestamp"
-	loggerConfig.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout("2006-01-02T15:04:05.9999Z")
+func Get() *zap.SugaredLogger {
+	if Log == nil {
+		tmpLogger := zap.NewExample()
+		loggerConfig := zap.NewProductionConfig()
+		loggerConfig.EncoderConfig.TimeKey = "@timestamp"
+		loggerConfig.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout("2006-01-02T15:04:05.9999Z")
 
-	consoleOutput := zapcore.Lock(os.Stdout)
-	consoleEncoder := zapcore.NewJSONEncoder(loggerConfig.EncoderConfig)
-	if cfg.Debug {
-		// use color and non-JSON logging in DEBUG mode
-		loggerConfig.Development = true
-		loggerConfig.EncoderConfig.EncodeLevel = zapcore.LowercaseColorLevelEncoder
-		consoleEncoder = zapcore.NewConsoleEncoder(loggerConfig.EncoderConfig)
-	}
+		consoleOutput := zapcore.Lock(os.Stdout)
+		consoleEncoder := zapcore.NewJSONEncoder(loggerConfig.EncoderConfig)
+		if cfg.Debug {
+			// use color and non-JSON logging in DEBUG mode
+			loggerConfig.Development = true
+			loggerConfig.EncoderConfig.EncodeLevel = zapcore.LowercaseColorLevelEncoder
+			consoleEncoder = zapcore.NewConsoleEncoder(loggerConfig.EncoderConfig)
+		}
 
-	switch cfg.LogLevel {
-	case "DEBUG":
-		loggerConfig.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
-	case "ERROR":
-		loggerConfig.Level = zap.NewAtomicLevelAt(zapcore.ErrorLevel)
-	default:
-		loggerConfig.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
-	}
+		switch cfg.LogLevel {
+		case "DEBUG":
+			loggerConfig.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
+		case "ERROR":
+			loggerConfig.Level = zap.NewAtomicLevelAt(zapcore.ErrorLevel)
+		default:
+			loggerConfig.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
+		}
 
-	fn := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool { return true })
-	core := zapcore.NewTee(zapcore.NewCore(consoleEncoder, consoleOutput, fn))
+		fn := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool { return true })
+		core := zapcore.NewTee(zapcore.NewCore(consoleEncoder, consoleOutput, fn))
 
-	// configure cloudwatch
-	if cfg.Logging != nil && cfg.Logging.Region != "" {
-		cred := credentials.NewStaticCredentials(cfg.Logging.AccessKeyID, cfg.Logging.SecretAccessKey, "")
-		awsconf := aws.NewConfig().WithRegion(cfg.Logging.Region).WithCredentials(cred)
-		hook, err := lc.NewBatchingHook(cfg.Logging.LogGroup, cfg.Hostname, awsconf, 10*time.Second)
+		// configure cloudwatch
+		if cfg.Logging != nil && cfg.Logging.Region != "" {
+			cred := credentials.NewStaticCredentials(cfg.Logging.AccessKeyID, cfg.Logging.SecretAccessKey, "")
+			awsconf := aws.NewConfig().WithRegion(cfg.Logging.Region).WithCredentials(cred)
+			hook, err := lc.NewBatchingHook(cfg.Logging.LogGroup, cfg.Hostname, awsconf, 10*time.Second)
+			if err != nil {
+				tmpLogger.Info(err.Error())
+			}
+			core = zapcore.NewTee(
+				zapcore.NewCore(consoleEncoder, consoleOutput, fn),
+				zapcore.NewCore(consoleEncoder, hook, fn),
+			)
+		}
+
+		logger, err := loggerConfig.Build(zap.WrapCore(func(zapcore.Core) zapcore.Core { return core }))
 		if err != nil {
 			tmpLogger.Info(err.Error())
 		}
-		core = zapcore.NewTee(
-			zapcore.NewCore(consoleEncoder, consoleOutput, fn),
-			zapcore.NewCore(consoleEncoder, hook, fn),
-		)
-	}
 
-	logger, err := loggerConfig.Build(zap.WrapCore(func(zapcore.Core) zapcore.Core { return core }))
-	if err != nil {
-		tmpLogger.Info(err.Error())
+		Log = logger.Sugar()
+		Log.Infof("log level set to %s", cfg.LogLevel)
 	}
-
-	Log = logger.Sugar()
-	Log.Infof("log level set to %s", cfg.LogLevel)
+	return Log
 }
 
 // ResponseLogger is a middleware that sets the ResponseLogger to the global default.

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -23,7 +23,7 @@ import (
 // Log is a global variable that carries the Sugared logger
 var Log *zap.SugaredLogger
 
-var cfg = config.ExportCfg
+var cfg = config.Get()
 
 func init() {
 	tmpLogger := zap.NewExample()

--- a/middleware/psks.go
+++ b/middleware/psks.go
@@ -6,7 +6,11 @@ package middleware
 
 import (
 	"net/http"
+
+	"github.com/redhatinsights/export-service-go/config"
 )
+
+var Cfg = config.Get()
 
 // SliceContainsString returns true if the specified target is present in the given slice.
 // TODO: if this function is needed elsewhere, it should be moved to a separate package.

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -10,46 +10,18 @@ import (
 	"net/http"
 
 	"github.com/redhatinsights/platform-go-middlewares/identity"
-
-	"github.com/redhatinsights/export-service-go/config"
-	"github.com/redhatinsights/export-service-go/logger"
 )
 
 type userIdentityKey int
 
 const (
 	UserIdentityKey userIdentityKey = iota
-	debugHeader     string          = "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEwMDAxIiwib3JnX2lkIjoiMTAwMDAwMDEiLCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMDAwMDAwMSJ9LCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ1c2VyX2RldiJ9fX0K"
-)
-
-var (
-	Cfg = config.Get()
-	log = logger.Log
 )
 
 type User struct {
 	AccountID      string
 	OrganizationID string
 	Username       string
-}
-
-// InjectDebugUserIdentity is a middleware that set a valid x-rh-identity header
-// when operating in DEBUG mode. ** Only used during testing.
-func InjectDebugUserIdentity(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if Cfg.Debug {
-			rawHeaders := r.Header["X-Rh-Identity"]
-
-			// request does not have the x-rh-id header
-			if len(rawHeaders) != 1 {
-
-				r.Header["X-Rh-Identity"] = []string{debugHeader}
-				log.Info("injecting debug header")
-			}
-		}
-
-		next.ServeHTTP(w, r)
-	})
 }
 
 // EnforeUserIdentity is a middleware that checks for a valid x-rh-identity

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -23,7 +23,7 @@ const (
 )
 
 var (
-	Cfg = config.ExportCfg
+	Cfg = config.Get()
 	log = logger.Log
 )
 

--- a/models/db.go
+++ b/models/db.go
@@ -132,6 +132,7 @@ func (edb *ExportDB) Raw(sql string, values ...interface{}) *gorm.DB {
 
 func (edb *ExportDB) DeleteExpiredExports() error {
 	exportConfig := config.Get()
+	log := logger.Get()
 
 	columnsToReturn := []clause.Column{{Name: "id"}, {Name: "account_id"}, {Name: "organization_id"}, {Name: "username"}}
 	expiredExportsClause := fmt.Sprintf("now() > expires + interval '%d days'", exportConfig.ExportExpiryDays)
@@ -139,12 +140,12 @@ func (edb *ExportDB) DeleteExpiredExports() error {
 	var deletedExports []ExportPayload
 	err := edb.DB.Clauses(clause.Returning{Columns: columnsToReturn}).Where(expiredExportsClause).Delete(&deletedExports).Error
 	if err != nil {
-		logger.Log.Error("Unable to remove expired exports from the database", "error", err)
+		log.Error("Unable to remove expired exports from the database", "error", err)
 		return err
 	}
 
 	for _, export := range deletedExports {
-		logger.Log.Debugw("Deleted expired export",
+		log.Debugw("Deleted expired export",
 			"id", export.ID,
 			"org_id", export.OrganizationID,
 			"account", export.AccountID,

--- a/models/db.go
+++ b/models/db.go
@@ -131,9 +131,10 @@ func (edb *ExportDB) Raw(sql string, values ...interface{}) *gorm.DB {
 }
 
 func (edb *ExportDB) DeleteExpiredExports() error {
+	exportConfig := config.Get()
 
 	columnsToReturn := []clause.Column{{Name: "id"}, {Name: "account_id"}, {Name: "organization_id"}, {Name: "username"}}
-	expiredExportsClause := fmt.Sprintf("now() > expires + interval '%d days'", config.ExportCfg.ExportExpiryDays)
+	expiredExportsClause := fmt.Sprintf("now() > expires + interval '%d days'", exportConfig.ExportExpiryDays)
 
 	var deletedExports []ExportPayload
 	err := edb.DB.Clauses(clause.Returning{Columns: columnsToReturn}).Where(expiredExportsClause).Delete(&deletedExports).Error

--- a/models/db.go
+++ b/models/db.go
@@ -131,11 +131,10 @@ func (edb *ExportDB) Raw(sql string, values ...interface{}) *gorm.DB {
 }
 
 func (edb *ExportDB) DeleteExpiredExports() error {
-	exportConfig := config.Get()
 	log := logger.Get()
 
 	columnsToReturn := []clause.Column{{Name: "id"}, {Name: "account_id"}, {Name: "organization_id"}, {Name: "username"}}
-	expiredExportsClause := fmt.Sprintf("now() > expires + interval '%d days'", exportConfig.ExportExpiryDays)
+	expiredExportsClause := fmt.Sprintf("now() > expires + interval '%d days'", edb.Cfg.ExportExpiryDays)
 
 	var deletedExports []ExportPayload
 	err := edb.DB.Clauses(clause.Returning{Columns: columnsToReturn}).Where(expiredExportsClause).Delete(&deletedExports).Error

--- a/models/models.go
+++ b/models/models.go
@@ -87,9 +87,11 @@ type User struct {
 }
 
 func (ep *ExportPayload) BeforeCreate(tx *gorm.DB) (err error) {
+	exportConfig := config.Get()
+
 	ep.ID = uuid.New()
 	if ep.Expires == nil {
-		expirationTime := time.Now().AddDate(0, 0, config.ExportCfg.ExportExpiryDays)
+		expirationTime := time.Now().AddDate(0, 0, exportConfig.ExportExpiryDays)
 		ep.Expires = &expirationTime
 	}
 	for i := range ep.Sources {

--- a/models/purge_expired_exports_test.go
+++ b/models/purge_expired_exports_test.go
@@ -22,11 +22,12 @@ var _ = Describe("Purge expired exports", func() {
 
 	var (
 		dbConnection *gorm.DB
+		exportConfig = config.Get()
 	)
 
 	BeforeEach(func() {
 		var err error
-		dbConnection, err = db.OpenDB(*config.Get())
+		dbConnection, err = db.OpenDB(*exportConfig)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -46,7 +47,7 @@ var _ = Describe("Purge expired exports", func() {
 
 			exportDB := models.ExportDB{
 				DB:  dbConnection,
-				Cfg: config.Get(),
+				Cfg: exportConfig,
 			}
 
 			err = exportDB.DeleteExpiredExports()

--- a/models/purge_expired_exports_test.go
+++ b/models/purge_expired_exports_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Purge expired exports", func() {
 
 	BeforeEach(func() {
 		var err error
-		dbConnection, err = db.OpenDB(*config.ExportCfg)
+		dbConnection, err = db.OpenDB(*config.Get())
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -46,7 +46,7 @@ var _ = Describe("Purge expired exports", func() {
 
 			exportDB := models.ExportDB{
 				DB:  dbConnection,
-				Cfg: config.ExportCfg,
+				Cfg: config.Get(),
 			}
 
 			err = exportDB.DeleteExpiredExports()

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -5,20 +5,14 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"go.uber.org/zap"
 
 	econfig "github.com/redhatinsights/export-service-go/config"
-	"github.com/redhatinsights/export-service-go/logger"
-)
-
-var (
-	Client *s3.Client
-	cfg    = econfig.ExportCfg
-	log    = logger.Log
 )
 
 const defaultRegion = "us-east-1"
 
-func init() {
+func NewS3Client(cfg econfig.ExportConfig, log *zap.SugaredLogger) *s3.Client {
 	scfg := cfg.StorageConfig
 
 	resolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
@@ -42,6 +36,6 @@ func init() {
 		EndpointResolverWithOptions: resolver,
 	}
 
-	Client = s3.NewFromConfig(s3cfg)
 	log.Infof("s3 client configured")
+	return s3.NewFromConfig(s3cfg)
 }


### PR DESCRIPTION
## What?
Replace usage of `init()` in the logging, config, and s3 packages.

## Why?
Gives more control over the order packages are initialized and prevents race conditions in the code.

## How?
Change the functions to be explicitly called using `Get()`.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
