### PR TITLE
[RHCLOUD-23341] Set logLevel based on env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ monitor-topic:
 	$(OCI_TOOL) exec -ti kafka /usr/bin/kafka-console-consumer --bootstrap-server localhost:9092 --topic platform.export.requests
 
 run-api: build-local migrate_db
-	DEBUG=true MINIO_PORT=9099 AWS_ACCESS_KEY=minio AWS_SECRET_ACCESS_KEY=minioadmin PSKS=testing-a-psk PUBLICPORT=8000 METRICSPORT=9090 PRIVATEPORT=10010 PGSQL_PORT=5432 ./export-service api_server
+	DEBUG=true MINIO_PORT=9099 AWS_ACCESS_KEY=minio AWS_SECRET_ACCESS_KEY=minioadmin PSKS=testing-a-psk PUBLIC_PORT=8000 METRICS_PORT=9090 PRIVATE_PORT=10010 PGSQL_PORT=5432 ./export-service api_server
 
 migrate_db: build-local
 	PGSQL_PORT=5432 ./export-service migrate_db upgrade

--- a/config/config.go
+++ b/config/config.go
@@ -112,8 +112,9 @@ func Get() *ExportConfig {
 
 		options.AutomaticEnv()
 
-		if options.GetBool("Debug") {
-			options.Set("LogLevel", "DEBUG")
+		logLevel, present := os.LookupEnv("LOG_LEVEL")
+		if present {
+			options.Set("LogLevel", logLevel)
 		}
 
 		kubenv := viper.New()

--- a/config/config.go
+++ b/config/config.go
@@ -84,14 +84,14 @@ var doOnce sync.Once
 func Get() *ExportConfig {
 	doOnce.Do(func() {
 		options := viper.New()
-		options.SetDefault("PublicPort", 8000)
-		options.SetDefault("MetricsPort", 9000)
-		options.SetDefault("PrivatePort", 10000)
-		options.SetDefault("LogLevel", "INFO")
-		options.SetDefault("Debug", false)
-		options.SetDefault("OpenAPIFilePath", "./static/spec/openapi.json")
-		options.SetDefault("psks", strings.Split(os.Getenv("EXPORTS_PSKS"), ","))
-		options.SetDefault("Export_Expiriy_Days", 7)
+		options.SetDefault("PUBLIC_PORT", 8000)
+		options.SetDefault("METRICS_PORT", 9000)
+		options.SetDefault("PRIVATE_PORT", 10000)
+		options.SetDefault("LOG_LEVEL", "INFO")
+		options.SetDefault("DEBUG", false)
+		options.SetDefault("OPEN_API_FILE_PATH", "./static/spec/openapi.json")
+		options.SetDefault("PSKS", strings.Split(os.Getenv("EXPORTS_PSKS"), ","))
+		options.SetDefault("EXPORT_EXPIRY_DAYS", 7)
 
 		// DB defaults
 		options.SetDefault("PGSQL_USER", "postgres")
@@ -106,30 +106,25 @@ func Get() *ExportConfig {
 		options.SetDefault("MINIO_SSL", false)
 
 		// Kafka defaults
-		options.SetDefault("KafakAnnounceTopic", ExportTopic)
-		options.SetDefault("KafkaBrokers", strings.Split(os.Getenv("KAFKA_BROKERS"), ","))
-		options.SetDefault("KafkaGroupID", "export")
+		options.SetDefault("KAFKA_ANNOUNCE_TOPIC", ExportTopic)
+		options.SetDefault("KAFKA_BROKERS", strings.Split(os.Getenv("KAFKA_BROKERS"), ","))
+		options.SetDefault("KAFKA_GROUP_ID", "export")
 
 		options.AutomaticEnv()
-
-		logLevel, present := os.LookupEnv("LOG_LEVEL")
-		if present {
-			options.Set("LogLevel", logLevel)
-		}
 
 		kubenv := viper.New()
 		kubenv.AutomaticEnv()
 
 		config = &ExportConfig{
 			Hostname:         kubenv.GetString("Hostname"),
-			PublicPort:       options.GetInt("PublicPort"),
-			MetricsPort:      options.GetInt("MetricsPort"),
-			PrivatePort:      options.GetInt("PrivatePort"),
-			Debug:            options.GetBool("Debug"),
-			LogLevel:         options.GetString("LogLevel"),
-			OpenAPIFilePath:  options.GetString("OpenAPIFilePath"),
-			Psks:             options.GetStringSlice("psks"),
-			ExportExpiryDays: options.GetInt("Export_Expiriy_Days"),
+			PublicPort:       options.GetInt("PUBLIC_PORT"),
+			MetricsPort:      options.GetInt("METRICS_PORT"),
+			PrivatePort:      options.GetInt("PRIVATE_PORT"),
+			Debug:            options.GetBool("DEBUG"),
+			LogLevel:         options.GetString("LOG_LEVEL"),
+			OpenAPIFilePath:  options.GetString("OPEN_API_FILE_PATH"),
+			Psks:             options.GetStringSlice("PSKS"),
+			ExportExpiryDays: options.GetInt("EXPORT_EXPIRY_DAYS"),
 		}
 
 		config.DBConfig = dbConfig{
@@ -152,9 +147,9 @@ func Get() *ExportConfig {
 		}
 
 		config.KafkaConfig = kafkaConfig{
-			Brokers:      options.GetStringSlice("KafkaBrokers"),
-			GroupID:      options.GetString("KafkaGroupID"),
-			ExportsTopic: options.GetString("KafakAnnounceTopic"),
+			Brokers:      options.GetStringSlice("KAFKA_BROKERS"),
+			GroupID:      options.GetString("KAFKA_GROUP_ID"),
+			ExportsTopic: options.GetString("KAFKA_ANNOUNCE_TOPIC"),
 		}
 
 		if clowder.IsClowderEnabled() {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,15 +10,15 @@ services:
       - PGSQL_PORT=5432
       - PGSQL_HOSTNAME=export-db
       - DEBUG=true
-      - OPENAPIFILEPATH=/var/tmp/openapi.json
+      - OPEN_API_FILE_PATH=/var/tmp/openapi.json
       - PSKS=testing-a-psk
       - KAFKA_BROKERS=kafka:29092
       - AWS_ACCESS_KEY=minio
       - AWS_SECRET_ACCESS_KEY=minioadmin
-      - PUBLICPORT=8000
-      - METRICSPORT=9090
+      - PUBLIC_PORT=8000
+      - METRICS_PORT=9090
       - MINIO_PORT=9099
-      - PRIVATEPORT=10010
+      - PRIVATE_PORT=10010
     ports:
       - 8000:8000
       - 9090:9090


### PR DESCRIPTION
## What?
[RHCLOUD-23341](https://issues.redhat.com/browse/RHCLOUD-23341)
Set logLevel from `LOG_LEVEL` env as part of setting up CloudWatch logging

## Why?
So that logLevel can be changed through clowder

## How?
Change logLevel to set from env in config

## Testing
N/A

## Anything Else?
Modified ENV field names to match a common naming convention

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
