### PR TITLE
set logLevel for service

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -61,6 +61,8 @@ objects:
           value: ${OPEN_API_FILE_PATH}
         - name: EXPORT_SERVICE_BUCKET
           value: ${EXPORT_SERVICE_BUCKET}
+        - name: LOG_LEVEL
+          value: ${LOG_LEVEL}
         - name: EXPORTS_PSKS
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## What?
LOG_LEVEL was set for `export-service-init` but not `export-service-service`