### PR TITLE
Update OpenAPI spec path

### DIFF
--- a/static/spec/openapi.json
+++ b/static/spec/openapi.json
@@ -6,7 +6,7 @@
   },
   "servers": [
     {
-      "url": "{server}/api/export/v1",
+      "url": "{server}/api/insights-export-service/v1",
       "variables": {
         "server": {
           "default": "http://localhost:8080"

--- a/static/spec/openapi.yaml
+++ b/static/spec/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: consoledot Export Service
   version: 0.1.0
 servers:
-  - url: '{server}/api/export/v1'
+  - url: '{server}/api/insights-export-service/v1'
     variables:
       server:
         default: http://localhost:8080


### PR DESCRIPTION
## What?
Enabling export-service on Stage

- RHCLOUD-25366
- RHCLOUD-23338
- RHCLOUD-25381


## Why?
There's a difference between the API Spec path and the entry in Stage

## How?
To fix this either requires a change on the API Gateway, or in the app's API spec file. This PR does the latter.

## Testing
can't really test anything without deploying it first

## Anything Else?
N/A

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
