### PR TITLE
Fix issues with internal API requestBody in API spec

### DIFF
--- a/static/spec/openapi.json
+++ b/static/spec/openapi.json
@@ -338,10 +338,14 @@
                 "properties": {
                   "message": {
                     "type": "string",
-                    "example": "not found"
+                    "description": "A human-readable error message describing the problem",
+                    "example": "The requested resource does not exist"
                   },
                   "error": {
                     "type": "integer",
+                    "description": "The HTTP status code of the error",
+                    "minimum": 400,
+                    "maximum": 599,
                     "example": 404
                   }
                 }

--- a/static/spec/openapi.json
+++ b/static/spec/openapi.json
@@ -266,8 +266,14 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
-            "application/zip": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            },
+            "application/csv": {
               "schema": {
                 "type": "string",
                 "format": "binary"
@@ -317,22 +323,22 @@
               "type": "string"
             },
             "required": true
-          },
-          {
-            "name": "code",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "message",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "example": {
+                  "message": "not found",
+                  "error": 404
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "202": {
             "description": "OK"

--- a/static/spec/openapi.json
+++ b/static/spec/openapi.json
@@ -331,9 +331,19 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "example": {
-                  "message": "not found",
-                  "error": 404
+                "required": [
+                  "message",
+                  "error"
+                ],
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "example": "not found"
+                  },
+                  "error": {
+                    "type": "integer",
+                    "example": 404
+                  }
                 }
               }
             }

--- a/static/spec/openapi.yaml
+++ b/static/spec/openapi.yaml
@@ -199,7 +199,14 @@ paths:
           application/json:
             schema:
               type: object
-              example: { "message": "not found", "error": 404 }
+              required: [message, error]
+              properties:
+                message:
+                  type: string
+                  example: "not found"
+                error:
+                  type: integer
+                  example: 404
       responses:
         '202':
           description: OK

--- a/static/spec/openapi.yaml
+++ b/static/spec/openapi.yaml
@@ -203,9 +203,13 @@ paths:
               properties:
                 message:
                   type: string
-                  example: "not found"
+                  description: A human-readable error message describing the problem
+                  example: "The requested resource does not exist"
                 error:
                   type: integer
+                  description: The HTTP status code of the error
+                  minimum: 400
+                  maximum: 599
                   example: 404
       responses:
         '202':

--- a/static/spec/openapi.yaml
+++ b/static/spec/openapi.yaml
@@ -158,8 +158,12 @@ paths:
             type: string
           required: true
       requestBody:
+        required: true
         content:
-          application/zip:
+          application/json:
+            schema:
+              type: object
+          application/csv:
             schema:
               type: string
               format: binary
@@ -189,14 +193,13 @@ paths:
           schema:
             type: string
           required: true
-        - name: code
-          in: query
-          schema:
-            type: string
-        - name: message
-          in: query
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              example: { "message": "not found", "error": 404 }
       responses:
         '202':
           description: OK


### PR DESCRIPTION
## What?
Some of the information in our `openapi.yaml` and `openapi.json` were incorrect.

## Why?
Allow other applications to clearly understand how to integrate with the export-service API

## How?
- Updated the requestBody of the `upload` endpoint to expect `application/json` or `application/csv`
- Updated the requestBody of the `error` endpoint to expect the correct query parameters and `application/json`
- Gave an example of the `json` sent to the `error` endpoint

## Testing

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
