### PR TITLE
Set initial value of 0 for uploadSizes metric

### DIFF
--- a/s3/metrics.go
+++ b/s3/metrics.go
@@ -23,4 +23,6 @@ func init() {
 	prometheus.MustRegister(totalUploads)
 	prometheus.MustRegister(failUploads)
 	prometheus.MustRegister(uploadSizes)
+	// Set an initial value of 0 for the histogram so that it shows up in the metrics
+	uploadSizes.With(prometheus.Labels{"account": "testAccount", "org_id": "testOrg", "app": "testApp"})
 }


### PR DESCRIPTION
## What?
Set `export_service_upload_sizes` metric to 0 by default

## Why?
So that the metric shows up in Grafana, even if not upload has happened yet

## How?
Do an empty observe on initialization of the metric

## Testing
Testing locally, the metric is visible

## Anything Else?
https://www.robustperception.io/existential-issues-with-metrics/

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
