### PR TITLE
[RHCLOUD-25841] Fix bug with incorrect error code from internal endpoint

### DIFF
--- a/exports/api_models.go
+++ b/exports/api_models.go
@@ -24,6 +24,10 @@ type Source struct {
 	Status      string         `json:"status"`
 	Resource    string         `json:"resource"`
 	Filters     datatypes.JSON `json:"filters"`
-	Message     *string        `json:"message,omitempty"`
-	Code        *int           `json:"code,omitempty"`
+	SourceError
+}
+
+type SourceError struct {
+	Message *string `json:"message,omitempty"`
+	Code    *int    `json:"error,omitempty"`
 }

--- a/exports/internal_test.go
+++ b/exports/internal_test.go
@@ -93,7 +93,7 @@ var _ = Context("Set up internal handler", func() {
 			source := sources[0].(map[string]interface{})
 			resourceUUID := source["id"].(string)
 
-			// upload a payload with some dummy data
+			// upload the resource with some dummy data
 			rr = httptest.NewRecorder()
 			dummyBody := `{"data": "dummy data"}`
 			req = httptest.NewRequest("POST", fmt.Sprintf("/app/export/v1/upload/%s/exampleApp/%s", exportUUID, resourceUUID), bytes.NewBuffer([]byte(dummyBody)))
@@ -135,10 +135,10 @@ var _ = Context("Set up internal handler", func() {
 			resourceUUID := source["id"].(string)
 			fmt.Println(resourceUUID)
 
-			// upload a payload with some dummy data
+			// return an error for the resource
 			rr = httptest.NewRecorder()
-			dummyBody := `{"data": "dummy data"}`
-			req = httptest.NewRequest("POST", fmt.Sprintf("/app/export/v1/error/%s/exampleApp/%s", exportUUID, resourceUUID), bytes.NewBuffer([]byte(dummyBody)))
+			errorBody := `{"message": "test error", "error": 123}`
+			req = httptest.NewRequest("POST", fmt.Sprintf("/app/export/v1/error/%s/exampleApp/%s", exportUUID, resourceUUID), bytes.NewBuffer([]byte(errorBody)))
 			AddDebugUserIdentity(req)
 			router.ServeHTTP(rr, req)
 			Expect(rr.Code).To(Equal(http.StatusAccepted))
@@ -154,6 +154,11 @@ var _ = Context("Set up internal handler", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			exportStatus := exportResponse2["status"].(string)
 			Expect(exportStatus).To(Equal("failed"))
+			// check that the message and code for the export source error are correct
+			sources = exportResponse2["sources"].([]interface{})
+			source = sources[0].(map[string]interface{})
+			Expect(source["message"].(string)).To(Equal("test error"))
+			Expect(source["error"].(float64)).To(Equal(123.0))
 		})
 	})
 })


### PR DESCRIPTION
## What?
[RHCLOUD-25841](https://issues.redhat.com/browse/RHCLOUD-25841)
When the internal api returns an error `/error` it passes `"message"` and `"error"`. 

In the DB, the error code from `"error"` is stored as the field `Code`. This caused an issue with the parsing that was causing the error in the DB to always be set to `0` regardless of the returned `"error"`

## Why?
So that the correct error code is stored from the internal `/error`.

## How?
Parse the `/error` json into the API schema (which has the correct `json` tags), then put it back into the DB schema.

## Testing
Modified tests to check that error code and message are properly set after `/error`

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
