### PR TITLE
fix issues with created_at, expires_at, and completed_at

### DIFF
--- a/exports/exports.go
+++ b/exports/exports.go
@@ -266,6 +266,15 @@ func (e *Export) getExportWithUser(w http.ResponseWriter, r *http.Request, logge
 }
 
 func DBExportToAPI(payload models.ExportPayload) ExportPayload {
+	// UTC required to format as ISO 8601
+	payload.CreatedAt = payload.CreatedAt.UTC()
+	if payload.CompletedAt != nil {
+		*payload.CompletedAt = payload.CompletedAt.UTC()
+	}
+	if payload.Expires != nil {
+		*payload.Expires = payload.Expires.UTC()
+	}
+
 	apiPayload := ExportPayload{
 		ID:          payload.ID.String(),
 		CreatedAt:   payload.CreatedAt,

--- a/exports/exports_test.go
+++ b/exports/exports_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 const debugHeader string = "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEwMDAxIiwib3JnX2lkIjoiMTAwMDAwMDEiLCJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMDAwMDAwMSJ9LCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ1c2VyX2RldiJ9fX0K"
+const formatDateTime string = "2006-01-02T15:04:05Z" // ISO 8601
 
 func AddDebugUserIdentity(req *http.Request) {
 	req.Header.Add("x-rh-identity", debugHeader)
@@ -170,7 +171,7 @@ var _ = Describe("The public API", func() {
 
 			rr := httptest.NewRecorder()
 
-			today := time.Now().Format(time.RFC3339)
+			today := time.Now().UTC().Format(formatDateTime)
 
 			req, err := http.NewRequest("GET", fmt.Sprintf("/api/export/v1/exports?created_at=%s", today), nil)
 
@@ -576,8 +577,8 @@ func populateTestData() chi.Router {
 		router.ServeHTTP(rr, req)
 	}
 
-	oneDayAgo := time.Now().AddDate(0, 0, -1)
-	oneDayFromNow := time.Now().AddDate(0, 0, 1)
+	oneDayAgo := time.Now().AddDate(0, 0, -1).UTC()
+	oneDayFromNow := time.Now().AddDate(0, 0, 1).UTC()
 
 	modifyExportCreated("Test Export Request 1", oneDayAgo)
 	modifyExportCreated("Test Export Request 2", oneDayFromNow)

--- a/exports/request_resources.go
+++ b/exports/request_resources.go
@@ -62,7 +62,7 @@ func KafkaRequestApplicationResources(kafkaChan chan *kafka.Message) RequestAppl
 					Subject:     payload.ID.String(),
 					SpecVersion: kafkaConfig.EventSpecVersion,
 					Type:        kafkaConfig.EventType,
-					Time:        time.Now().Format(time.RFC3339),
+					Time:        time.Now().UTC().Format(formatDateTime),
 					OrgID:       payload.OrganizationID,
 					DataSchema:  kafkaConfig.EventDataSchema,
 					Data: cloudEventSchema.ExportRequestClass{

--- a/exports/utils.go
+++ b/exports/utils.go
@@ -11,7 +11,7 @@ import (
 const (
 	formatDate     = "2006-01-02"
 	formatDateLen  = 10
-	formatDateTime = time.RFC3339
+	formatDateTime = "2006-01-02T15:04:05Z" // ISO 8601
 )
 
 func initQuery(q url.Values) (result models.QueryParams, err error) {

--- a/s3/compress.go
+++ b/s3/compress.go
@@ -23,6 +23,8 @@ import (
 	"github.com/redhatinsights/export-service-go/models"
 )
 
+const formatDateTime = "2006-01-02T15:04:05Z" // ISO 8601
+
 type Compressor struct {
 	Bucket string
 	Log    *zap.SugaredLogger
@@ -194,7 +196,7 @@ func (c *Compressor) Compress(ctx context.Context, m *models.ExportPayload) (tim
 
 	c.Log.Infof("starting payload compression for %s", m.ID)
 	prefix := fmt.Sprintf("%s/%s/", m.OrganizationID, m.ID)
-	filename := fmt.Sprintf("%s-%s.tar.gz", t.Format(time.RFC3339), m.ID.String())
+	filename := fmt.Sprintf("%s-%s.tar.gz", t.UTC().Format(formatDateTime), m.ID.String())
 	s3key := fmt.Sprintf("%s/%s", m.OrganizationID, filename)
 
 	sources, err := m.GetSources()
@@ -204,7 +206,7 @@ func (c *Compressor) Compress(ctx context.Context, m *models.ExportPayload) (tim
 
 	meta := ExportMeta{
 		ExportBy:    m.User.Username,
-		ExportDate:  m.CreatedAt.Format(time.RFC3339),
+		ExportDate:  m.CreatedAt.UTC().Format(formatDateTime),
 		ExportOrgID: m.User.OrganizationID,
 		HelpString:  helpString,
 	}

--- a/static/spec/openapi.json
+++ b/static/spec/openapi.json
@@ -57,7 +57,7 @@
           },
           {
             "name": "created_at",
-            "description": "Date follows the RFC3339 standard or YYYY-MM-DD",
+            "description": "Date follows the ISO8601 standard or YYYY-MM-DD",
             "in": "query",
             "schema": {
               "type": "string",
@@ -66,7 +66,7 @@
           },
           {
             "name": "expires_at",
-            "description": "Date follows the RFC3339 standard or YYYY-MM-DD",
+            "description": "Date follows the ISO8601 standard or YYYY-MM-DD",
             "in": "query",
             "schema": {
               "type": "string",

--- a/static/spec/openapi.json
+++ b/static/spec/openapi.json
@@ -277,10 +277,6 @@
           "resource": {
             "type": "string"
           },
-          "expires_at": {
-            "type": "string",
-            "format": "date-time"
-          },
           "filters": {
             "type": "object"
           }

--- a/static/spec/openapi.yaml
+++ b/static/spec/openapi.yaml
@@ -33,13 +33,13 @@ paths:
           schema:
             type: string
         - name: created_at
-          description: Date follows the RFC3339 standard or YYYY-MM-DD
+          description: Date follows the ISO8601 standard or YYYY-MM-DD
           in: query
           schema:
             type: string
             format: date
         - name: expires_at
-          description: Date follows the RFC3339 standard or YYYY-MM-DD
+          description: Date follows the ISO8601 standard or YYYY-MM-DD
           in: query
           schema:
             type: string

--- a/static/spec/openapi.yaml
+++ b/static/spec/openapi.yaml
@@ -171,9 +171,6 @@ components:
           type: string
         resource:
           type: string
-        expires_at:
-          type: string
-          format: date-time
         filters:
           type: object
     ExportRequest:


### PR DESCRIPTION
## What?
- the dateTime values returned in responses were formatted as `RFC3336` but not the standard `ISO8601`
https://ijmacd.github.io/rfc3339-iso8601/
- the api spec incorrectly noted that expires_at could be defined per-source

## Why?
fix issues with autogenerated api client

## How?
- remove expiration set per source in the api spec
- explicitly set formatting to match `ISO8601` and be in `UTC` timezone

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
