### PR TITLE
[RHCLOUD-26590] Handle missing fields on /error endpoint

### DIFF
--- a/exports/api_models.go
+++ b/exports/api_models.go
@@ -28,6 +28,6 @@ type Source struct {
 }
 
 type SourceError struct {
-	Message *string `json:"message,omitempty"`
-	Code    *int    `json:"error,omitempty"`
+	Message string `json:"message,omitempty"`
+	Code    int    `json:"error,omitempty"`
 }

--- a/exports/exports.go
+++ b/exports/exports.go
@@ -294,8 +294,8 @@ func DBExportToAPI(payload models.ExportPayload) ExportPayload {
 		}
 
 		if source.SourceError != nil {
-			newSource.Message = &source.SourceError.Message
-			newSource.Code = &source.SourceError.Code
+			newSource.Message = source.SourceError.Message
+			newSource.Code = source.SourceError.Code
 		}
 
 		apiPayload.Sources = append(apiPayload.Sources, newSource)

--- a/exports/internal.go
+++ b/exports/internal.go
@@ -60,10 +60,14 @@ func (i *Internal) PostError(w http.ResponseWriter, r *http.Request) {
 		BadRequestError(w, err.Error())
 		return
 	}
+	if sourceError.Message == "" || sourceError.Code == 0 {
+		BadRequestError(w, "Both 'message' and 'code' are required fields")
+		return
+	}
 	// convert the json error to a db error (because 'error' is called 'code' in the db)
 	modelError := models.SourceError{
-		Message: *sourceError.Message,
-		Code:    *sourceError.Code,
+		Message: sourceError.Message,
+		Code:    sourceError.Code,
 	}
 
 	payload, err := i.DB.Get(params.ExportUUID)


### PR DESCRIPTION
## What?
[RHCLOUD-26590] Handle missing fields on /error endpoint

## Why?
Previously, if an application sends back an error through the internal API, and the incoming body doesn't have the expected keys or has an empty JSON object "{}", then the export service crashes with a `500` Internal Server Error.

## How?
Make the `Message` and `Code` fields required in the `SourceError` struct, and add a check that both are populated for incoming calls to `/error`

## Testing
Added `Returns a 400 error when the user's error is missing a required field` to `internal_test.go`

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
