### PR TITLE
[RHCLOUD-26597] Handle missing format and filters in export request

### DIFF
--- a/exports/exports.go
+++ b/exports/exports.go
@@ -331,7 +331,7 @@ func APIExportToDBExport(apiPayload ExportPayload) (*models.ExportPayload, error
 	case "json":
 		payload.Format = models.JSON
 	default:
-		return nil, fmt.Errorf("unknown payload format: %s", apiPayload.Format)
+		return nil, fmt.Errorf("invalid or missing payload format")
 	}
 
 	switch apiPayload.Status {

--- a/exports/exports_test.go
+++ b/exports/exports_test.go
@@ -37,6 +37,9 @@ func generateExportRequestBody(name, format, expires, sources string) (exportReq
 	if expires != "" {
 		return []byte(fmt.Sprintf(`{"name": "%s", "format": "%s", "expires_at": "%s", "sources": [%s]}`, name, format, expires, sources))
 	}
+	if format == "" {
+		return []byte(fmt.Sprintf(`{"name": "%s", "sources": [%s]}`, name, sources))
+	}
 	return []byte(fmt.Sprintf(`{"name": "%s", "format": "%s", "sources": [%s]}`, name, format, sources))
 }
 
@@ -64,6 +67,7 @@ var _ = Describe("The public API", func() {
 		Entry("with valid request", "Test Export Request", "json", "2023-01-01T00:00:00Z", `{"application":"exampleApp", "resource":"exampleResource"}`, "", http.StatusAccepted),
 		Entry("with no expiration", "Test Export Request", "json", "", `{"application":"exampleApp", "resource":"exampleResource"}`, "", http.StatusAccepted),
 		Entry("with an invalid format", "Test Export Request", "abcde", "2023-01-01T00:00:00Z", `{"application":"exampleApp", "resource":"exampleResource"}`, "invalid or missing payload format", http.StatusBadRequest),
+		Entry("with a missing format", "Test Export Request", "", "2023-01-01T00:00:00Z", `{"application":"exampleApp", "resource":"exampleResource"}`, "invalid or missing payload format", http.StatusBadRequest),
 		Entry("With no sources", "Test Export Request", "json", "2023-01-01T00:00:00Z", "", "no sources provided", http.StatusBadRequest),
 	)
 

--- a/exports/exports_test.go
+++ b/exports/exports_test.go
@@ -63,7 +63,7 @@ var _ = Describe("The public API", func() {
 	},
 		Entry("with valid request", "Test Export Request", "json", "2023-01-01T00:00:00Z", `{"application":"exampleApp", "resource":"exampleResource"}`, "", http.StatusAccepted),
 		Entry("with no expiration", "Test Export Request", "json", "", `{"application":"exampleApp", "resource":"exampleResource"}`, "", http.StatusAccepted),
-		Entry("with an invalid format", "Test Export Request", "abcde", "2023-01-01T00:00:00Z", `{"application":"exampleApp", "resource":"exampleResource"}`, "unknown payload format", http.StatusBadRequest),
+		Entry("with an invalid format", "Test Export Request", "abcde", "2023-01-01T00:00:00Z", `{"application":"exampleApp", "resource":"exampleResource"}`, "invalid or missing payload format", http.StatusBadRequest),
 		Entry("With no sources", "Test Export Request", "json", "2023-01-01T00:00:00Z", "", "no sources provided", http.StatusBadRequest),
 	)
 
@@ -516,6 +516,22 @@ var _ = Describe("The public API", func() {
 		router.ServeHTTP(rr, req)
 		Expect(rr.Code).To(Equal(http.StatusNotFound))
 		Expect(rr.Body.String()).To(ContainSubstring("not found"))
+	})
+
+	It("returns the appropriate error if the format is missing", func() {
+		router := setupTest(mockRequestApplicationResources)
+
+		rr := httptest.NewRecorder()
+
+		exportRequest := []byte(fmt.Sprintf(`{"name": "%s", "sources": [%s]}`, "Test Export Request", `{"application":"exampleApp", "resource":"exampleResource"}`))
+		req, err := http.NewRequest("POST", "/api/export/v1/exports", bytes.NewBuffer(exportRequest))
+		Expect(err).To(BeNil())
+		req.Header.Set("Content-Type", "application/json")
+
+		AddDebugUserIdentity(req)
+		router.ServeHTTP(rr, req)
+		Expect(rr.Code).To(Equal(http.StatusBadRequest))
+		Expect(rr.Body.String()).To(ContainSubstring("invalid or missing payload format"))
 	})
 })
 

--- a/exports/request_resources.go
+++ b/exports/request_resources.go
@@ -37,12 +37,13 @@ func KafkaRequestApplicationResources(kafkaChan chan *kafka.Message) RequestAppl
 			}
 
 			for _, source := range sources {
-				filters, err := ekafka.JsonToMap(source.Filters)
-				if err != nil {
-					log.Errorw("failed unmarshalling filters", "error", err)
-					// FIXME:
-					// return err
-					continue // Skip this source and continue with the next one
+				var filters map[string]interface{}
+
+				if source.Filters != nil && len(source.Filters) > 0 {
+					filters, err = ekafka.JsonToMap(source.Filters)
+					if err != nil {
+						log.Errorw("failed unmarshalling filters", "error", err)
+					}
 				}
 
 				format, ok := ekafka.ParseFormat(string(payload.Format))
@@ -69,13 +70,13 @@ func KafkaRequestApplicationResources(kafkaChan chan *kafka.Message) RequestAppl
 					DataSchema:  kafkaConfig.EventDataSchema,
 					Data: cloudEventSchema.ResourceRequest{
 						ResourceRequest: cloudEventSchema.ResourceRequestClass{
-							Application: source.Application,
+							Application:       source.Application,
 							ExportRequestUUID: payload.ID.String(),
-							Filters:     filters,
-							Format:      format,
-							Resource:    source.Resource,
-							UUID:        source.ID.String(),
-							XRhIdentity: identity,
+							Filters:           filters,
+							Format:            format,
+							Resource:          source.Resource,
+							UUID:              source.ID.String(),
+							XRhIdentity:       identity,
 						},
 					},
 				}


### PR DESCRIPTION
## What?
[RHCLOUD-26597](https://issues.redhat.com/browse/RHCLOUD-26597)
Handle missing `format` and/or `filters` in export requests. Filters is not a required field, and an error should be returned to the user if they pass an incorrect format.

## Why?
Kafka message to request resources is not sent if `format` or `filters` fields are absent in the export request. These resources are incorrectly skipped over instead of the user being notified that something was wrong with their request.

## How?
- Handle case of filters being empty in `KafkaRequestApplicationResources`
- Updated `APIExportToDBExport` to correctly throw an error for missing/incorrect filter.

## Testing
- Added test for missing/incorrect `format` field
- Locally tested that a kafka message is sent for requests missing `filters`

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
