### PR TITLE
[RHCLOUD-27042] Remove tagged path that contains uuid

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -14,14 +14,14 @@ import (
 var httpReqs = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "export_service_http_requests_total",
-		Help: "How many HTTP requests processed, partitioned by status code, http method and path.",
+		Help: "How many HTTP requests processed, partitioned by status code and http method.",
 	},
 	[]string{"code", "method"},
 )
 
 var httpDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Name: "export_service_http_response_time_seconds",
-	Help: "Duration of HTTP requests, partitioned by path.",
+	Help: "Duration of HTTP requests.",
 }, []string{"method"})
 
 type responseWriter struct {


### PR DESCRIPTION
## What?
Remove usage of tag `path` in metrics

## Why?
Some metrics are tagged by `path` and this causes an issue when the path contains the unique identifier of an export. Remove tracking by path here, and instead only track by `method` for these metrics.

## How?
Remove `path` from `httpReqs` and `httpDuration`

## Testing
Checked local metrics did not contain tag `path`
```
# TYPE export_service_http_requests_total counter
export_service_http_requests_total{code="202",method="POST"} 1
# HELP export_service_http_response_time_seconds Duration of HTTP requests.
# TYPE export_service_http_response_time_seconds histogram
export_service_http_response_time_seconds_bucket{method="POST",le="0.005"} 1
```

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
