### PR TITLE
[RHCLOUD-27691] Set containers to run as non-admin user 1000

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -92,6 +92,7 @@ objects:
               memory: 256Mi
         securityContext:
           runAsNonRoot: true
+          runAsUser: 1000
 
     database:
       name: export-service
@@ -127,6 +128,7 @@ objects:
             memory: 64Mi
         securityContext:
           runAsNonRoot: true
+          runAsUser: 1000
 
 
 - apiVersion: v1


### PR DESCRIPTION
## What?
[RHCLOUD-27691](https://issues.redhat.com/browse/RHCLOUD-27691)

## Why?
Running containers as non-root users limits the attack surface and prevents malicious actors from exploiting the root privileges.

## How?
Set `runAsUser: 1000` where `1000` is a non-root user

## Testing

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
