### PR TITLE
Remove security context and fix cronjob schedule

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -189,7 +189,7 @@ parameters:
   - name: EXPORT_SERVICE_BUCKET
     value: exports-bucket
   - name: CLEANER_SCHEDULE
-    value: "* 1 * * *"
+    value: "0 1 * * *"
   - name: EXPORTS_PSKS
     value: testing-a-psk
   - name: LOG_LEVEL

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -90,9 +90,6 @@ objects:
             requests:
               cpu: 250m
               memory: 256Mi
-        securityContext:
-          runAsNonRoot: true
-          runAsUser: 1000
 
     database:
       name: export-service
@@ -126,9 +123,6 @@ objects:
           requests:
             cpu: 100m
             memory: 64Mi
-        securityContext:
-          runAsNonRoot: true
-          runAsUser: 1000
 
 
 - apiVersion: v1


### PR DESCRIPTION
## What?
- Remove the security context definitions from Clowdapp template
- fixing the Cronjob schedule

## Why?
- About security context: shouldn't be needed, no service requires this, unless AppSRE is enforcing a new rule. Pending from a reply from AppSRE
- About cronjob: confirmed with @dehort  , the cronjob should only run once a day.

## How?
- just removing them from the template
- by adjusting the cronjob schedule syntax.

## Testing
- I deployed the app on an ephemeral environment using this template, using a bonfire config template override 

the template looks like

```yaml
apps:
- name: export_service_custom
  components:
    - name: export_service
      host: local
      repo: /home/vmugicag/dev/projects/export-service-go
      path: deploy/clowdapp.yaml
```

then deployed it with:

```
bonfire deploy export_service_custom 
```

I created a demo job out of the cronjob with

```
 oc create job foobar --from=cronjob/export-service-cleaner
```

I then examined the `Deployment` object  and the `job` generated by the cronjob using `oc edit` and saw the `securityContext` was empty. I also checked that (at least on Ephemeral) the `securityContext` assigned to the pods generated by the jobs and the `Deployment` objects had (as expected) a security context that had the expected security context (run as a non-root, random UID)


## Anything Else?
Nope

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
