### PR TITLE
Adjust the way the kafka sasl and ca cert configuration is handled

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -203,23 +203,28 @@ func Get() *ExportConfig {
 				fmt.Println("WARNING: Export requests kafka topic is not set within Clowder!")
 			}
 
+			config.KafkaConfig.SSLConfig = kafkaSSLConfig{}
+
 			broker := cfg.Kafka.Brokers[0]
-			if broker.Authtype != nil {
+
+			if broker.Cacert != nil {
 				caPath, err := cfg.KafkaCa(broker)
 				if err != nil {
 					panic("Kafka CA failed to write")
 				}
+				config.KafkaConfig.SSLConfig.CA = caPath
+			}
+
+			if broker.Authtype != nil {
 				securityProtocol := "sasl_ssl"
 				if broker.SecurityProtocol != nil {
 					securityProtocol = *broker.SecurityProtocol
 				}
-				config.KafkaConfig.SSLConfig = kafkaSSLConfig{
-					Username:      *broker.Sasl.Username,
-					Password:      *broker.Sasl.Password,
-					SASLMechanism: *broker.Sasl.SaslMechanism,
-					Protocol:      securityProtocol,
-					CA:            caPath,
-				}
+
+				config.KafkaConfig.SSLConfig.Username = *broker.Sasl.Username
+				config.KafkaConfig.SSLConfig.Password = *broker.Sasl.Password
+				config.KafkaConfig.SSLConfig.SASLMechanism = *broker.Sasl.SaslMechanism
+				config.KafkaConfig.SSLConfig.Protocol = securityProtocol
 			}
 
 			config.Logging = &loggingConfig{

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -92,21 +92,23 @@ func NewProducer() (*Producer, error) {
 		"loglevel", cfg.LogLevel,
 		"debug", cfg.Debug,
 	)
+
 	kcfg := &kafka.ConfigMap{
 		"bootstrap.servers": brokers,
 		"client.id":         cfg.Hostname,
 	}
+
 	if cfg.KafkaConfig.SSLConfig.SASLMechanism != "" {
 		ssl := cfg.KafkaConfig.SSLConfig
-		kcfg = &kafka.ConfigMap{
-			"bootstrap.servers": brokers,
-			"client.id":         cfg.Hostname,
-			"security.protocol": ssl.Protocol,
-			"sasl.mechanism":    ssl.SASLMechanism,
-			"ssl.ca.location":   ssl.CA,
-			"sasl.username":     ssl.Username,
-			"sasl.password":     ssl.Password,
-		}
+
+		_ = kcfg.SetKey("security.protocol", ssl.Protocol)
+		_ = kcfg.SetKey("sasl.mechanism", ssl.SASLMechanism)
+		_ = kcfg.SetKey("sasl.username", ssl.Username)
+		_ = kcfg.SetKey("sasl.password", ssl.Password)
+	}
+
+	if cfg.KafkaConfig.SSLConfig.CA != "" {
+		_ = kcfg.SetKey("ssl.ca.location", cfg.KafkaConfig.SSLConfig.CA)
 	}
 
 	p, err := kafka.NewProducer(kcfg)


### PR DESCRIPTION
Adjust the way the kafka sasl and ca cert configuration is handled

Stage is currently crash looping.  I hope this fixes it.

Here's the error:

```
panic: Kafka CA failed to write

goroutine 1 [running]:
github.com/redhatinsights/export-service-go/config.Get.func1()
/workspace/config/config.go:210 +0x187e
sync.(*Once).doSlow(0xd111ad9d11b8a76b?, 0xc830d44fc000b480?)
/usr/lib/golang/src/sync/once.go:74 +0xc2
sync.(*Once).Do(...)
/usr/lib/golang/src/sync/once.go:65
github.com/redhatinsights/export-service-go/config.Get()
/workspace/config/config.go:91 +0x31
github.com/redhatinsights/export-service-go/logger.init()
/workspace/logger/logger.go:26 +0x17
```

The code is expecting a ca cert, but one is not provided because the kafka cert is signed by an already trusted ca.  We need to separate the ca cert related config and the sasl related config as these things can vary unrelated to each other.