### PR TITLE
Add CRCD secrets

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,16 +1,18 @@
 def secrets = [
-    [path: params.VAULT_PATH_SVC_ACCOUNT_EPHEMERAL, engineVersion: 1, secretValues: [
+    [path: params.VAULT_PATH_SVC_ACCOUNT_EPHEMERAL, secretValues: [
         [envVar: 'OC_LOGIN_TOKEN_DEV', vaultKey: 'oc-login-token-dev'],
-        [envVar: 'OC_LOGIN_SERVER_DEV', vaultKey: 'oc-login-server-dev']]],
-    [path: params.VAULT_PATH_QUAY_PUSH, engineVersion: 1, secretValues: [
+        [envVar: 'OC_LOGIN_SERVER_DEV', vaultKey: 'oc-login-server-dev'],
+        [envVar: 'OC_LOGIN_TOKEN', vaultKey: 'oc-login-token'],
+        [envVar: 'OC_LOGIN_SERVER', vaultKey: 'oc-login-server']]],
+    [path: params.VAULT_PATH_QUAY_PUSH, secretValues: [
         [envVar: 'QUAY_USER', vaultKey: 'user'],
         [envVar: 'QUAY_TOKEN', vaultKey: 'token']]],
-    [path: params.VAULT_PATH_RHR_PULL, engineVersion: 1, secretValues: [
+    [path: params.VAULT_PATH_RHR_PULL, secretValues: [
         [envVar: 'RH_REGISTRY_USER', vaultKey: 'user'],
         [envVar: 'RH_REGISTRY_TOKEN', vaultKey: 'token']]]
 ]
 
-def configuration = [vaultUrl: params.VAULT_ADDRESS, vaultCredentialId: params.VAULT_CREDS_ID, engineVersion: 1]
+def configuration = [vaultUrl: params.VAULT_ADDRESS, vaultCredentialId: params.VAULT_CREDS_ID]
 
 pipeline {
     agent { label 'insights' }


### PR DESCRIPTION
## What?
This adds CRCD variables from Vault to be able to run the tests in the CRCD cluster (compared to the Ephemeral cluster).

## Why?
The Ephemeral cluster is busted ATM and this allows the tests to run on a diff. cluster

## How?
We have changed the default cluster but we need the right credentials injected into the pipeline, this PR does that

## Testing
no - it should actually be able to run the Smoke tests now.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
