### PR TITLE
Fix psk name in openapi manifests for private endpoint

### DIFF
--- a/static/spec/private.json
+++ b/static/spec/private.json
@@ -169,7 +169,7 @@
       "psk": {
         "type": "apiKey",
         "in": "header",
-        "name": "x-rh-export-psk"
+        "name": "x-rh-exports-psk"
       }
     }
   }

--- a/static/spec/private.yaml
+++ b/static/spec/private.yaml
@@ -107,4 +107,4 @@ components:
     psk:
       type: apiKey
       in: header
-      name: x-rh-export-psk
+      name: x-rh-exports-psk


### PR DESCRIPTION
## What?
Related to [SWATCH-1969](https://issues.redhat.com/browse/SWATCH-1969). 
I wanted to use the internal openapi spec from [here](https://github.com/RedHatInsights/export-service-go/blob/48077b1a04e025f2282f924d98846c7bafc8796d/static/spec/private.yaml) and when testing the generated client using the export service locally which I ran using the instructions from the README, it failed because the expected psk was not provided "x-rh-exports-psk". 

## Why?
This is failing because the openapi spec defines "x-rh-export-psk" (note the missing `s` character) instead of "x-rh-exports-psk". After amending this, the test passes. 

## How?

## Testing
I tested these changes using the instructions from the linked PR: https://github.com/RedHatInsights/rhsm-subscriptions/pull/2932

## Anything Else?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
