### PR TITLE
Update OpenAPI spec return code and examples

### DIFF
--- a/static/spec/openapi.json
+++ b/static/spec/openapi.json
@@ -78,7 +78,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "example": "subscriptions"
+              "example": "urn:redhat:application:notifications"
             }
           },
           {
@@ -86,7 +86,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "example": "systems"
+              "example": "urn:redhat:application:notifications:export:events"
             }
           },
           {

--- a/static/spec/openapi.yaml
+++ b/static/spec/openapi.yaml
@@ -17,7 +17,7 @@ paths:
             schema:
               $ref: '#/components/schemas/ExportRequest'
       responses:
-        '200':
+        '202':
           description: Export scheduled
           content:
             application/json:


### PR DESCRIPTION
## What?
Fix the following issue:

[RHCLOUD-31427](https://issues.redhat.com/browse/RHCLOUD-31427) - Returning 202 response instead of 200 as documented on POST /exports
[RHCLOUD-31443](https://issues.redhat.com/browse/RHCLOUD-31443) - Default values for GET /exports are incorrect in API documentation

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
