### PR TITLE
Remove workstream name from archive readme text.

### DIFF
--- a/example_export_manifest.md
+++ b/example_export_manifest.md
@@ -25,6 +25,4 @@ This archive contains the following data:
   - startDate: 2022-02-01T00:00:00Z
 
 ## Help and Support
-This service is owned by the ConsoleDot Pipeline team. If you have any questions, or need support with this service, please contact Red Hat Support.
-
-You can also raise an issue on the [Export Service GitHub repo](https://github.com/RedHatInsights/export-service-go/).
+If you have any questions, or need support with this service, please contact Red Hat Support or visit the [Export Service GitHub repo](https://github.com/RedHatInsights/export-service-go/).

--- a/s3/template.go
+++ b/s3/template.go
@@ -132,9 +132,7 @@ This archive contains the following data:
 %s
 
 ## Help and Support
-This service is owned by the ConsoleDot Pipeline team. If you have any questions, or need support with this service, please contact Red Hat Support.
-
-You can also raise an issue on the [Export Service GitHub repo](https://github.com/RedHatInsights/export-service-go/).
+If you have any questions, or need support with this service, please contact Red Hat Support or visit the [Export Service GitHub repo](https://github.com/RedHatInsights/export-service-go/).
 `,
 		meta.ExportBy,
 		meta.ExportOrgID,

--- a/s3/template_test.go
+++ b/s3/template_test.go
@@ -72,9 +72,7 @@ No failures reported.
 
 
 ## Help and Support
-This service is owned by the ConsoleDot Pipeline team. If you have any questions, or need support with this service, please contact Red Hat Support.
-
-You can also raise an issue on the [Export Service GitHub repo](https://github.com/RedHatInsights/export-service-go/).
+If you have any questions, or need support with this service, please contact Red Hat Support or visit the [Export Service GitHub repo](https://github.com/RedHatInsights/export-service-go/).
 `,
 		),
 		Entry("No sources", s3.ExportMeta{
@@ -102,9 +100,7 @@ No failures reported.
 
 
 ## Help and Support
-This service is owned by the ConsoleDot Pipeline team. If you have any questions, or need support with this service, please contact Red Hat Support.
-
-You can also raise an issue on the [Export Service GitHub repo](https://github.com/RedHatInsights/export-service-go/).
+If you have any questions, or need support with this service, please contact Red Hat Support or visit the [Export Service GitHub repo](https://github.com/RedHatInsights/export-service-go/).
 `,
 		),
 		Entry("One source with filters", s3.ExportMeta{
@@ -143,9 +139,7 @@ No failures reported.
 
 
 ## Help and Support
-This service is owned by the ConsoleDot Pipeline team. If you have any questions, or need support with this service, please contact Red Hat Support.
-
-You can also raise an issue on the [Export Service GitHub repo](https://github.com/RedHatInsights/export-service-go/).
+If you have any questions, or need support with this service, please contact Red Hat Support or visit the [Export Service GitHub repo](https://github.com/RedHatInsights/export-service-go/).
 `,
 		),
 		Entry("One failed file", s3.ExportMeta{
@@ -213,9 +207,7 @@ This archive contains the following data:
 
 
 ## Help and Support
-This service is owned by the ConsoleDot Pipeline team. If you have any questions, or need support with this service, please contact Red Hat Support.
-
-You can also raise an issue on the [Export Service GitHub repo](https://github.com/RedHatInsights/export-service-go/).
+If you have any questions, or need support with this service, please contact Red Hat Support or visit the [Export Service GitHub repo](https://github.com/RedHatInsights/export-service-go/).
 `,
 		),
 		Entry("Multiple sources", s3.ExportMeta{
@@ -271,9 +263,7 @@ No failures reported.
 
 
 ## Help and Support
-This service is owned by the ConsoleDot Pipeline team. If you have any questions, or need support with this service, please contact Red Hat Support.
-
-You can also raise an issue on the [Export Service GitHub repo](https://github.com/RedHatInsights/export-service-go/).
+If you have any questions, or need support with this service, please contact Red Hat Support or visit the [Export Service GitHub repo](https://github.com/RedHatInsights/export-service-go/).
 `,
 		),
 	)


### PR DESCRIPTION
## What?
Replace internal name with more generic support statement

[RHCLOUD-31429](https://issues.redhat.com/browse/RHCLOUD-31429) - Export service - meta.json mentions internal team name

## Why?
Internal team names are not identifiable to external users



## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
