### PR TITLE
Use zip instead of tar/gzip for the default export format

### DIFF
--- a/s3/compress.go
+++ b/s3/compress.go
@@ -139,12 +139,12 @@ func (c *Compressor) zipExport(ctx context.Context, prefix, filename, s3key stri
 	for _, fileToAdd := range files {
 		zipFile, err := zipWriter.Create(fileToAdd.Name)
 		if err != nil {
-			return fmt.Errorf("failed to create file %s in zip file: %w", err)
+			return fmt.Errorf("failed to create file %s in zip file: %w", fileToAdd.Name, err)
 		}
 
 		_, err = zipFile.Write(fileToAdd.Body)
 		if err != nil {
-			return fmt.Errorf("failed to write file %s to zip file: %w", err)
+			return fmt.Errorf("failed to write file %s to zip file: %w", fileToAdd.Name, err)
 		}
 	}
 

--- a/s3/compress.go
+++ b/s3/compress.go
@@ -88,7 +88,7 @@ func (c *Compressor) zipExport(ctx context.Context, prefix, filename, s3key stri
 
 	c.Log.Infof("shipping %s to s3", filename)
 	if _, err := c.Upload(ctx, tempExportFile, &c.Cfg.StorageConfig.Bucket, &s3key); err != nil {
-		return fmt.Errorf("failed to upload zipfile `%s` to s3: %w", s3key, err)
+		return fmt.Errorf("failed to upload zip file `%s` to s3: %w", s3key, err)
 	}
 
 	return nil
@@ -194,18 +194,12 @@ func writeFilesToZip(log *zap.SugaredLogger, files []s3FileData, meta ExportMeta
 		}
 
 		log.Infof("added file %s to payload", f.basename)
+
 	}
 
 	if err := addMetadataFilesToZip(&meta, zipWriter); err != nil {
 		return nil, err
 	}
-
-	/*
-		// produce zip
-		if err := zipWriter.Close(); err != nil {
-			return fmt.Errorf("failed to close gzip writer: %w", err)
-		}
-	*/
 
 	return &buf, nil
 }


### PR DESCRIPTION
RHCLOUD-33208

Needs more testing...I ripped out the function and tested it manually/directly (I hacked it together to run outside of the service) because podman is giving me trouble.

Not sure about compression...

We really need to break this function up.  Right now it has too many responsibilites.  It downloads the files from s3, builds the zip file, then uploads the zip file to s3.  Splitting it up would make it easier to understand and easier to test.

Some info on compression:  https://tanaikech.github.io/2018/10/23/zip-compression-of-downloaded-file-using-golang/

## What?
Explain what the change is linking any relevant JIRAs or Issues.

## Why?
Consider what business or engineering goal does this PR achieves.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
