### PR TITLE
Use the newer v2 version of request-id middleware

### DIFF
--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -16,8 +16,8 @@ import (
 	middleware "github.com/go-chi/chi/v5/middleware"
 	redoc "github.com/go-openapi/runtime/middleware"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/redhatinsights/platform-go-middlewares/request_id"
 	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
+	"github.com/redhatinsights/platform-go-middlewares/v2/request_id"
 	"go.uber.org/zap"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"

--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -40,7 +40,7 @@ func createPublicServer(cfg *config.ExportConfig, external exports.Export) *http
 
 	// setup middleware
 	router.Use(
-		request_id.RequestID,
+		request_id.ConfiguredRequestID("x-rh-insights-request-id"),
 		emiddleware.JSONContentType, // Set content-Type headers as application/json
 		logger.ResponseLogger,
 		setupDocsMiddleware,

--- a/exports/exports.go
+++ b/exports/exports.go
@@ -13,7 +13,7 @@ import (
 
 	chi "github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
-	"github.com/redhatinsights/platform-go-middlewares/request_id"
+	"github.com/redhatinsights/platform-go-middlewares/v2/request_id"
 	"go.uber.org/zap"
 
 	"github.com/redhatinsights/export-service-go/config"

--- a/exports/internal.go
+++ b/exports/internal.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 
 	chi "github.com/go-chi/chi/v5"
-	"github.com/redhatinsights/platform-go-middlewares/request_id"
+	"github.com/redhatinsights/platform-go-middlewares/v2/request_id"
 	"go.uber.org/zap"
 
 	"github.com/redhatinsights/export-service-go/config"

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	middleware "github.com/go-chi/chi/v5/middleware"
-	"github.com/redhatinsights/platform-go-middlewares/request_id"
+	"github.com/redhatinsights/platform-go-middlewares/v2/request_id"
 	lc "github.com/redhatinsights/platform-go-middlewares/v2/logging/cloudwatch"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -12,8 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	middleware "github.com/go-chi/chi/v5/middleware"
-	"github.com/redhatinsights/platform-go-middlewares/v2/request_id"
 	lc "github.com/redhatinsights/platform-go-middlewares/v2/logging/cloudwatch"
+	"github.com/redhatinsights/platform-go-middlewares/v2/request_id"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 


### PR DESCRIPTION
Use the newer v2 version of request-id middleware
Configure the request-id middleware to use the right name of the request-id header...otherwise the middleware creates its own and returns that