### PR TITLE
Explicitly pass the logger through the s3 code

### DIFF
--- a/exports/exports.go
+++ b/exports/exports.go
@@ -190,7 +190,7 @@ func (e *Export) GetExport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out, err := e.StorageHandler.GetObject(r.Context(), export.S3Key)
+	out, err := e.StorageHandler.GetObject(r.Context(), logger, export.S3Key)
 	if err != nil {
 		logger.Errorw("failed to get object", "error", err)
 		InternalServerError(w, err)

--- a/exports/internal.go
+++ b/exports/internal.go
@@ -161,7 +161,7 @@ func (i *Internal) PostUpload(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusAccepted)
 
-	if err := i.Compressor.CreateObject(r.Context(), i.DB, r.Body, params.Application, params.ResourceUUID, payload); err != nil {
+	if err := i.Compressor.CreateObject(r.Context(), logger, i.DB, r.Body, params.Application, params.ResourceUUID, payload); err != nil {
 		Logerr(w.Write([]byte(fmt.Sprintf("payload failed to upload: %v", err))))
 	} else {
 		Logerr(w.Write([]byte("payload delivered")))


### PR DESCRIPTION
Explicitly pass the logger through the s3 code.  Part of this code runs asynchronously.  As a result, we can lose context by using the class level logger.

Passing the logger is kinda gross, but so is adding the ids (state/context) to the Context (golang Context type here) and reconstructing the logger in each method.