### PR TITLE
check for leaks

### DIFF
--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -31,6 +31,7 @@ import (
 	emiddleware "github.com/redhatinsights/export-service-go/middleware"
 	"github.com/redhatinsights/export-service-go/models"
 	es3 "github.com/redhatinsights/export-service-go/s3"
+	s3_manager "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 )
 
 // func serveWeb(cfg *config.ExportConfig, consumers []services.ConsumerService) *http.Server {
@@ -195,6 +196,9 @@ func startApiServer(cfg *config.ExportConfig, log *zap.SugaredLogger) {
 		Log:    log,
 		Client: *s3Client,
 		Cfg:    *cfg,
+        Uploader: s3_manager.NewUploader(s3Client, func(u *s3_manager.Uploader) {
+            u.PartSize = 100 * 1024 * 1024 // 100 MiB
+        }),
 	}
 
 	external := exports.Export{

--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -85,6 +85,7 @@ func createPrivateServer(cfg *config.ExportConfig, internal exports.Internal) *h
 	// Initialize router
 	router := chi.NewRouter()
 
+
 	// setup middleware
 	router.Use(
 		request_id.RequestID,
@@ -94,8 +95,8 @@ func createPrivateServer(cfg *config.ExportConfig, internal exports.Internal) *h
 		middleware.Recoverer,
 	)
 
-	router.Get("/", statusOK)
 	router.Mount("/debug", middleware.Profiler())
+	router.Get("/", statusOK)
 
 	router.Route("/app/export/v1", func(r chi.Router) {
 		r.Use(emiddleware.EnforcePSK)

--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -163,12 +163,18 @@ func startApiServer(cfg *config.ExportConfig, log *zap.SugaredLogger) {
 	log.Infow("configuration values",
 		"hostname", cfg.Hostname,
 		"publicport", cfg.PublicPort,
+		"public_http_server_read_timeout", cfg.PublicHttpServerReadTimeout,
+		"public_http_server_write_timeout", cfg.PublicHttpServerWriteTimeout,
+		"private_http_server_read_timeout", cfg.PrivateHttpServerReadTimeout,
+		"private_http_server_write_timeout", cfg.PrivateHttpServerWriteTimeout,
 		"metricsport", cfg.MetricsPort,
 		"loglevel", cfg.LogLevel,
 		"debug", cfg.Debug,
 		"publicopenapifilepath", cfg.OpenAPIPublicPath,
 		"privateopenapifilepath", cfg.OpenAPIPrivatePath,
 		"exportableApplications", cfg.ExportableApplications,
+		"aws_uploader_buffer_size", cfg.StorageConfig.AwsUploaderBufferSize,
+		"aws_downloader_buffer_size", cfg.StorageConfig.AwsDownloaderBufferSize,
 	)
 
 	kafkaProducerMessagesChan := make(chan *kafka.Message) // TODO: determine an appropriate buffer (if one is actually necessary)

--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -197,10 +197,10 @@ func startApiServer(cfg *config.ExportConfig, log *zap.SugaredLogger) {
 		Client: *s3Client,
 		Cfg:    *cfg,
         Uploader: s3_manager.NewUploader(s3Client, func(u *s3_manager.Uploader) {
-            u.PartSize = 100 * 1024 * 1024 // 100 MiB
+            u.PartSize = 10 * 1024 * 1024 // 10 MiB
         }), 
         Downloader: s3_manager.NewDownloader(s3Client, func(d *s3_manager.Downloader) {
-            d.PartSize = 100 * 1024 * 1024 // 100 MiB
+            d.PartSize = 10 * 1024 * 1024 // 10 MiB
         }),
 	}
 

--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -95,6 +95,7 @@ func createPrivateServer(cfg *config.ExportConfig, internal exports.Internal) *h
 	)
 
 	router.Get("/", statusOK)
+	router.Mount("/debug", middleware.Profiler())
 
 	router.Route("/app/export/v1", func(r chi.Router) {
 		r.Use(emiddleware.EnforcePSK)

--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -94,7 +94,6 @@ func createPrivateServer(cfg *config.ExportConfig, internal exports.Internal) *h
 		middleware.Recoverer,
 	)
 
-	router.Mount("/debug", middleware.Profiler())
 	router.Get("/", statusOK)
 
 	router.Route("/app/export/v1", func(r chi.Router) {

--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -198,6 +198,9 @@ func startApiServer(cfg *config.ExportConfig, log *zap.SugaredLogger) {
 		Cfg:    *cfg,
         Uploader: s3_manager.NewUploader(s3Client, func(u *s3_manager.Uploader) {
             u.PartSize = 100 * 1024 * 1024 // 100 MiB
+        }), 
+        Downloader: s3_manager.NewDownloader(s3Client, func(d *s3_manager.Downloader) {
+            d.PartSize = 100 * 1024 * 1024 // 100 MiB
         }),
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -172,6 +172,8 @@ func Get() *ExportConfig {
 			},
 		}
 
+		config.Logging = &loggingConfig{}
+
 		config.StorageConfig = storageConfig{
 			Bucket:                  "exports-bucket",
 			Endpoint:                buildBaseHttpUrl(options.GetBool("MINIO_SSL"), options.GetString("MINIO_HOST"), options.GetInt("MINIO_PORT")),

--- a/config/config.go
+++ b/config/config.go
@@ -208,17 +208,13 @@ func Get() *ExportConfig {
 				panic("RDS CA failed to write: " + err.Error())
 			}
 
-			config.DBConfig = dbConfig{
-				User:     cfg.Database.Username,
-				Password: cfg.Database.Password,
-				Hostname: cfg.Database.Hostname,
-				Port:     fmt.Sprint(cfg.Database.Port),
-				Name:     cfg.Database.Name,
-				SSLCfg: dbSSLConfig{
-					SSLMode: cfg.Database.SslMode,
-					RdsCa:   rdsCaPath,
-				},
-			}
+			config.DBConfig.User = cfg.Database.Username
+			config.DBConfig.Password = cfg.Database.Password
+			config.DBConfig.Hostname = cfg.Database.Hostname
+			config.DBConfig.Port = fmt.Sprint(cfg.Database.Port)
+			config.DBConfig.Name = cfg.Database.Name
+			config.DBConfig.SSLCfg.SSLMode = cfg.Database.SslMode
+			config.DBConfig.SSLCfg.RdsCa = rdsCaPath
 
 			config.KafkaConfig.Brokers = clowder.KafkaServers
 			config.KafkaConfig.ExportsTopic = clowder.KafkaTopics[ExportTopic].Name
@@ -250,12 +246,10 @@ func Get() *ExportConfig {
 				config.KafkaConfig.SSLConfig.Protocol = securityProtocol
 			}
 
-			config.Logging = &loggingConfig{
-				AccessKeyID:     cfg.Logging.Cloudwatch.AccessKeyId,
-				SecretAccessKey: cfg.Logging.Cloudwatch.SecretAccessKey,
-				LogGroup:        cfg.Logging.Cloudwatch.LogGroup,
-				Region:          cfg.Logging.Cloudwatch.Region,
-			}
+			config.Logging.AccessKeyID = cfg.Logging.Cloudwatch.AccessKeyId
+			config.Logging.SecretAccessKey = cfg.Logging.Cloudwatch.SecretAccessKey
+			config.Logging.LogGroup = cfg.Logging.Cloudwatch.LogGroup
+			config.Logging.Region = cfg.Logging.Cloudwatch.Region
 
 			bucket := cfg.ObjectStore.Buckets[0]
 			config.StorageConfig.Bucket = exportBucketInfo.RequestedName

--- a/config/config.go
+++ b/config/config.go
@@ -179,7 +179,7 @@ func Get() *ExportConfig {
 			SecretKey:               options.GetString("AWS_SECRET_ACCESS_KEY"),
 			UseSSL:                  options.GetBool("MINIO_SSL"),
 			AwsUploaderBufferSize:   options.GetInt64("AWS_UPLOADER_BUFFER_SIZE"),
-			AwsDownloaderBufferSize: options.GetInt64("AWS_DOWNLOADER_LOADER_BUFFER_SIZE"),
+			AwsDownloaderBufferSize: options.GetInt64("AWS_DOWNLOADER_BUFFER_SIZE"),
 		}
 
 		config.KafkaConfig = kafkaConfig{

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 	"github.com/spf13/viper"
@@ -18,21 +19,25 @@ const ExportTopic string = "platform.export.requests"
 
 // ExportConfig represents the runtime configuration
 type ExportConfig struct {
-	Hostname               string
-	PublicPort             int
-	MetricsPort            int
-	PrivatePort            int
-	Logging                *loggingConfig
-	LogLevel               string
-	Debug                  bool
-	DBConfig               dbConfig
-	StorageConfig          storageConfig
-	KafkaConfig            kafkaConfig
-	OpenAPIPrivatePath     string
-	OpenAPIPublicPath      string
-	Psks                   []string
-	ExportExpiryDays       int
-	ExportableApplications map[string]map[string]bool
+	Hostname                      string
+	PublicPort                    int
+	PublicHttpServerReadTimeout   time.Duration
+	PublicHttpServerWriteTimeout  time.Duration
+	PrivateHttpServerReadTimeout  time.Duration
+	PrivateHttpServerWriteTimeout time.Duration
+	MetricsPort                   int
+	PrivatePort                   int
+	Logging                       *loggingConfig
+	LogLevel                      string
+	Debug                         bool
+	DBConfig                      dbConfig
+	StorageConfig                 storageConfig
+	KafkaConfig                   kafkaConfig
+	OpenAPIPrivatePath            string
+	OpenAPIPublicPath             string
+	Psks                          []string
+	ExportExpiryDays              int
+	ExportableApplications        map[string]map[string]bool
 }
 
 type dbConfig struct {
@@ -77,11 +82,13 @@ type kafkaSSLConfig struct {
 }
 
 type storageConfig struct {
-	Bucket    string
-	Endpoint  string
-	AccessKey string
-	SecretKey string
-	UseSSL    bool
+	Bucket                  string
+	Endpoint                string
+	AccessKey               string
+	SecretKey               string
+	UseSSL                  bool
+	AwsUploaderBufferSize   int64
+	AwsDownloaderBufferSize int64
 }
 
 var config *ExportConfig
@@ -94,6 +101,10 @@ func Get() *ExportConfig {
 		options.SetDefault("PUBLIC_PORT", 8000)
 		options.SetDefault("METRICS_PORT", 9000)
 		options.SetDefault("PRIVATE_PORT", 10000)
+		options.SetDefault("PUBLIC_HTTP_SERVER_READ_TIMEOUT", 5*time.Second)
+		options.SetDefault("PUBLIC_HTTP_SERVER_WRITE_TIMEOUT", 10*time.Second)
+		options.SetDefault("PRIVATE_HTTP_SERVER_READ_TIMEOUT", 5*time.Second)
+		options.SetDefault("PRIVATE_HTTP_SERVER_WRITE_TIMEOUT", 10*time.Second)
 		options.SetDefault("LOG_LEVEL", "INFO")
 		options.SetDefault("DEBUG", false)
 		options.SetDefault("OPEN_API_FILE_PATH", "./static/spec/openapi.json")
@@ -124,23 +135,30 @@ func Get() *ExportConfig {
 		options.SetDefault("KAFKA_EVENT_DATASCHEMA", "https://console.redhat.com/api/schemas/apps/export-service/v1/resource-request.json")
 		options.SetDefault("KAFKA_EVENT_SCHEMA", "https://console.redhat.com/api/schemas/events/v1/events.json")
 
+		options.SetDefault("AWS_UPLOADER_BUFFER_SIZE", 10*1024*1024)
+		options.SetDefault("AWS_DOWNLOADER_BUFFER_SIZE", 10*1024*1024)
+
 		options.AutomaticEnv()
 
 		kubenv := viper.New()
 		kubenv.AutomaticEnv()
 
 		config = &ExportConfig{
-			Hostname:               kubenv.GetString("Hostname"),
-			PublicPort:             options.GetInt("PUBLIC_PORT"),
-			MetricsPort:            options.GetInt("METRICS_PORT"),
-			PrivatePort:            options.GetInt("PRIVATE_PORT"),
-			Debug:                  options.GetBool("DEBUG"),
-			LogLevel:               options.GetString("LOG_LEVEL"),
-			OpenAPIPublicPath:      options.GetString("OPEN_API_FILE_PATH"),
-			OpenAPIPrivatePath:     options.GetString("OPEN_API_PRIVATE_PATH"),
-			Psks:                   options.GetStringSlice("PSKS"),
-			ExportExpiryDays:       options.GetInt("EXPORT_EXPIRY_DAYS"),
-			ExportableApplications: convertExportableAppsFromConfigToInternal(options.GetStringMapStringSlice("EXPORT_ENABLE_APPS")),
+			Hostname:                      kubenv.GetString("Hostname"),
+			PublicPort:                    options.GetInt("PUBLIC_PORT"),
+			MetricsPort:                   options.GetInt("METRICS_PORT"),
+			PrivatePort:                   options.GetInt("PRIVATE_PORT"),
+			PublicHttpServerReadTimeout:   options.GetDuration("PUBLIC_HTTP_SERVER_READ_TIMEOUT"),
+			PublicHttpServerWriteTimeout:  options.GetDuration("PUBLIC_HTTP_SERVER_WRITE_TIMEOUT"),
+			PrivateHttpServerReadTimeout:  options.GetDuration("PRIVATE_HTTP_SERVER_READ_TIMEOUT"),
+			PrivateHttpServerWriteTimeout: options.GetDuration("PRIVATE_HTTP_SERVER_WRITE_TIMEOUT"),
+			Debug:                         options.GetBool("DEBUG"),
+			LogLevel:                      options.GetString("LOG_LEVEL"),
+			OpenAPIPublicPath:             options.GetString("OPEN_API_FILE_PATH"),
+			OpenAPIPrivatePath:            options.GetString("OPEN_API_PRIVATE_PATH"),
+			Psks:                          options.GetStringSlice("PSKS"),
+			ExportExpiryDays:              options.GetInt("EXPORT_EXPIRY_DAYS"),
+			ExportableApplications:        convertExportableAppsFromConfigToInternal(options.GetStringMapStringSlice("EXPORT_ENABLE_APPS")),
 		}
 
 		config.DBConfig = dbConfig{
@@ -155,11 +173,13 @@ func Get() *ExportConfig {
 		}
 
 		config.StorageConfig = storageConfig{
-			Bucket:    "exports-bucket",
-			Endpoint:  buildBaseHttpUrl(options.GetBool("MINIO_SSL"), options.GetString("MINIO_HOST"), options.GetInt("MINIO_PORT")),
-			AccessKey: options.GetString("AWS_ACCESS_KEY"),
-			SecretKey: options.GetString("AWS_SECRET_ACCESS_KEY"),
-			UseSSL:    options.GetBool("MINIO_SSL"),
+			Bucket:                  "exports-bucket",
+			Endpoint:                buildBaseHttpUrl(options.GetBool("MINIO_SSL"), options.GetString("MINIO_HOST"), options.GetInt("MINIO_PORT")),
+			AccessKey:               options.GetString("AWS_ACCESS_KEY"),
+			SecretKey:               options.GetString("AWS_SECRET_ACCESS_KEY"),
+			UseSSL:                  options.GetBool("MINIO_SSL"),
+			AwsUploaderBufferSize:   options.GetInt64("AWS_UPLOADER_BUFFER_SIZE"),
+			AwsDownloaderBufferSize: options.GetInt64("AWS_DOWNLOADER_LOADER_BUFFER_SIZE"),
 		}
 
 		config.KafkaConfig = kafkaConfig{

--- a/config/config.go
+++ b/config/config.go
@@ -258,13 +258,11 @@ func Get() *ExportConfig {
 			}
 
 			bucket := cfg.ObjectStore.Buckets[0]
-			config.StorageConfig = storageConfig{
-				Bucket:    exportBucketInfo.RequestedName,
-				Endpoint:  buildBaseHttpUrl(cfg.ObjectStore.Tls, cfg.ObjectStore.Hostname, cfg.ObjectStore.Port),
-				AccessKey: *bucket.AccessKey,
-				SecretKey: *bucket.SecretKey,
-				UseSSL:    cfg.ObjectStore.Tls,
-			}
+			config.StorageConfig.Bucket = exportBucketInfo.RequestedName
+			config.StorageConfig.Endpoint = buildBaseHttpUrl(cfg.ObjectStore.Tls, cfg.ObjectStore.Hostname, cfg.ObjectStore.Port)
+			config.StorageConfig.AccessKey = *bucket.AccessKey
+			config.StorageConfig.SecretKey = *bucket.SecretKey
+			config.StorageConfig.UseSSL = cfg.ObjectStore.Tls
 		}
 	})
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -76,6 +76,10 @@ objects:
               key: psk-list
         - name: EXPORT_ENABLE_APPS
           value: ${EXPORT_ENABLE_APPS}
+        - name: AWS_UPLOADER_BUFFER_SIZE
+          value: ${AWS_UPLOADER_BUFFER_SIZE}
+        - name: AWS_DOWNLOADER_BUFFER_SIZE
+          value: ${AWS_DOWNLOADER_BUFFER_SIZE}
         initContainers:
         - args:
           - export-service
@@ -200,3 +204,15 @@ parameters:
     value: INFO
   - name: EXPORT_ENABLE_APPS
     value: "{\"exampleApplication\":[\"exampleResource\",\"anotherExampleResource\"],\"urn:redhat:application:inventory\":[\"urn:redhat:application:inventory:export:systems\"],\"urn:redhat:application:notifications\":[\"urn:redhat:application:notifications:export:events\"]}"
+  - name: AWS_UPLOADER_BUFFER_SIZE
+    value: "10485760"
+  - name: AWS_DOWNLOADER_BUFFER_SIZE
+    value: "10485760"
+  - name: PUBLIC_HTTP_SERVER_READ_TIMEOUT
+    value: "5s"
+  - name: PUBLIC_HTTP_SERVER_WRITE_TIMEOUT
+    value: "10s"
+  - name: PRIVATE_HTTP_SERVER_READ_TIMEOUT
+    value: "5s"
+  - name: PRIVATE_HTTP_SERVER_WRITE_TIMEOUT
+    value: "10s"

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -80,6 +80,14 @@ objects:
           value: ${AWS_UPLOADER_BUFFER_SIZE}
         - name: AWS_DOWNLOADER_BUFFER_SIZE
           value: ${AWS_DOWNLOADER_BUFFER_SIZE}
+        - name: PUBLIC_HTTP_SERVER_READ_TIMEOUT
+          value: ${PUBLIC_HTTP_SERVER_READ_TIMEOUT}
+        - name: PUBLIC_HTTP_SERVER_WRITE_TIMEOUT
+          value: ${PUBLIC_HTTP_SERVER_WRITE_TIMEOUT}
+        - name: PRIVATE_HTTP_SERVER_READ_TIMEOUT
+          value: ${PRIVATE_HTTP_SERVER_READ_TIMEOUT}
+        - name: PRIVATE_HTTP_SERVER_WRITE_TIMEOUT
+          value: ${PRIVATE_HTTP_SERVER_WRITE_TIMEOUT}
         initContainers:
         - args:
           - export-service

--- a/exports/internal.go
+++ b/exports/internal.go
@@ -32,7 +32,7 @@ type Internal struct {
 // InternalRouter is a router for all of the internal routes which require exportuuid,
 // application name, and resourceuuid.
 func (i *Internal) InternalRouter(r chi.Router) {
-	r.Mount("/debug", ch_middleware.Profiler())
+	r.Mount("/debug", chi_middleware.Profiler())
 	r.Route("/{exportUUID}/{application}/{resourceUUID}", func(sub chi.Router) {
 		sub.Use(middleware.URLParamsCtx)
 		sub.Post("/upload", i.PostUpload)

--- a/exports/internal.go
+++ b/exports/internal.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	chi "github.com/go-chi/chi/v5"
+	chi_middleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/redhatinsights/platform-go-middlewares/v2/request_id"
 	"go.uber.org/zap"
 
@@ -31,6 +32,7 @@ type Internal struct {
 // InternalRouter is a router for all of the internal routes which require exportuuid,
 // application name, and resourceuuid.
 func (i *Internal) InternalRouter(r chi.Router) {
+	r.Mount("/debug", ch_middleware.Profiler())
 	r.Route("/{exportUUID}/{application}/{resourceUUID}", func(sub chi.Router) {
 		sub.Use(middleware.URLParamsCtx)
 		sub.Post("/upload", i.PostUpload)

--- a/exports/internal.go
+++ b/exports/internal.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 
 	chi "github.com/go-chi/chi/v5"
-	chi_middleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/redhatinsights/platform-go-middlewares/v2/request_id"
 	"go.uber.org/zap"
 
@@ -32,7 +31,6 @@ type Internal struct {
 // InternalRouter is a router for all of the internal routes which require exportuuid,
 // application name, and resourceuuid.
 func (i *Internal) InternalRouter(r chi.Router) {
-	r.Mount("/debug", chi_middleware.Profiler())
 	r.Route("/{exportUUID}/{application}/{resourceUUID}", func(sub chi.Router) {
 		sub.Use(middleware.URLParamsCtx)
 		sub.Post("/upload", i.PostUpload)

--- a/s3/compress.go
+++ b/s3/compress.go
@@ -25,14 +25,13 @@ import (
 const formatDateTime = "2006-01-02T15:04:05Z" // ISO 8601
 
 type Compressor struct {
-	Bucket string
-	Log    *zap.SugaredLogger
-	Client s3.Client
-	Cfg    econfig.ExportConfig
-    Uploader *manager.Uploader
-    Downloader *manager.Downloader
+	Bucket     string
+	Log        *zap.SugaredLogger
+	Client     s3.Client
+	Cfg        econfig.ExportConfig
+	Uploader   *manager.Uploader
+	Downloader *manager.Downloader
 }
-
 
 // S3ListObjectsAPI defines the interface for the ListObjectsV2 function.
 // We use this interface to test the function using a mocked service.
@@ -289,7 +288,6 @@ func (c *Compressor) Download(ctx context.Context, logger *zap.SugaredLogger, w 
 
 	return c.Downloader.Download(ctx, w, input)
 }
-
 
 func (c *Compressor) Upload(ctx context.Context, logger *zap.SugaredLogger, body io.Reader, bucket, key *string) (*manager.UploadOutput, error) {
 

--- a/s3/compress.go
+++ b/s3/compress.go
@@ -30,6 +30,7 @@ type Compressor struct {
 	Client s3.Client
 	Cfg    econfig.ExportConfig
     Uploader *manager.Uploader
+    Downloader *manager.Downloader
 }
 
 
@@ -66,7 +67,7 @@ func (c *Compressor) zipExport(ctx context.Context, logger *zap.SugaredLogger, p
 	// Delete the contents of the temp directory when this function returns
 	defer os.RemoveAll(tempDirName)
 
-	downloadedFiles, err := downloadFilesFromS3(ctx, c.Cfg, logger, c.Bucket, prefix, tempDirName)
+	downloadedFiles, err := downloadFilesFromS3(ctx, c.Cfg, logger, c.Downloader, c.Bucket, prefix, tempDirName)
 	if err != nil {
 		return err
 	}
@@ -101,7 +102,8 @@ type s3FileData struct {
 	basename string
 }
 
-func downloadFilesFromS3(ctx context.Context, cfg econfig.ExportConfig, log *zap.SugaredLogger, bucket string, prefix string, tempDir string) ([]s3FileData, error) {
+func downloadFilesFromS3(ctx context.Context, cfg econfig.ExportConfig, log *zap.SugaredLogger, downloader *manager.Downloader, bucket string, prefix string, tempDir string) ([]s3FileData, error) {
+
 	input := &s3.ListObjectsV2Input{
 		Bucket: &bucket,
 		Prefix: &prefix,
@@ -129,10 +131,6 @@ func downloadFilesFromS3(ctx context.Context, cfg econfig.ExportConfig, log *zap
 		if err != nil {
 			return nil, fmt.Errorf("failed to create temp file: %w", err)
 		}
-
-		downloader := manager.NewDownloader(s3client, func(d *manager.Downloader) {
-			d.PartSize = 100 * 1024 * 1024 // 100 MiB
-		})
 
 		input := &s3.GetObjectInput{Bucket: &bucket, Key: obj.Key}
 
@@ -287,15 +285,9 @@ func (c *Compressor) Compress(ctx context.Context, logger *zap.SugaredLogger, m 
 }
 
 func (c *Compressor) Download(ctx context.Context, logger *zap.SugaredLogger, w io.WriterAt, bucket, key *string) (n int64, err error) {
-	s3client := NewS3Client(c.Cfg, c.Log)
-
-	downloader := manager.NewDownloader(s3client, func(d *manager.Downloader) {
-		d.PartSize = 100 * 1024 * 1024 // 100 MiB
-	})
-
 	input := &s3.GetObjectInput{Bucket: bucket, Key: key}
 
-	return downloader.Download(ctx, w, input)
+	return c.Downloader.Download(ctx, w, input)
 }
 
 


### PR DESCRIPTION
Share a single Uploader and Downloader instance
Make the Uploader/Downloader buffer sizes configurable
Make the http server's read and write timeouts configurable


Based on the documentation [1][2], it looks like the Uploader and Downloader can be shared between different go routines.

[1] https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/feature/s3/manager#Uploader
[2] https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/feature/s3/manager#Downloader
