### PR TITLE
feature: include the user agent in logs

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -100,6 +100,7 @@ func SetResponseLogger(l *zap.SugaredLogger) func(next http.Handler) http.Handle
 					"status", ww.Status(),
 					"size", ww.BytesWritten(),
 					"request_id", request_id.GetReqID(r.Context()),
+					"user-agent", r.UserAgent(),
 				)
 			}()
 			next.ServeHTTP(ww, r)


### PR DESCRIPTION
## What?
Includes the `User-Agent` header in the logs.

### Jira ticket
[[RHCLOUD-35359]](https://issues.redhat.com/browse/RHCLOUD-35359)

## Why?
Consider what business or engineering goal does this PR achieves.
Having the user agent in the logs will help debug issues that happen in the different environments. It will tell us whether the received requests are coming from an automated test suite, form a person who is manually sending requests, or if it comes from another integrated application.