### PR TITLE
Do not include the org-id, account number in the upload size metrics.…

### DIFF
--- a/s3/compress.go
+++ b/s3/compress.go
@@ -354,7 +354,7 @@ func (c *Compressor) CreateObject(ctx context.Context, logger *zap.SugaredLogger
 	if err != nil {
 		logger.Errorw("failed to get metric for upload size", "error", err)
 	} else {
-		uploadSizes.With(prometheus.Labels{"account": payload.AccountID, "org_id": payload.OrganizationID, "app": application}).Observe(float64(uploadSize))
+		uploadSizes.With(prometheus.Labels{"app": application}).Observe(float64(uploadSize))
 	}
 
 	return nil

--- a/s3/metrics.go
+++ b/s3/metrics.go
@@ -17,12 +17,18 @@ var failUploads = prometheus.NewCounter(prometheus.CounterOpts{
 var uploadSizes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Name: "export_service_upload_sizes",
 	Help: "Size of payloads posted",
-}, []string{"account", "org_id", "app"})
+	Buckets: []float64{
+		1024 * 10,
+		1024 * 100,
+		1024 * 1000,
+		1024 * 10000,
+	},
+}, []string{"app"})
 
 func init() {
 	prometheus.MustRegister(totalUploads)
 	prometheus.MustRegister(failUploads)
 	prometheus.MustRegister(uploadSizes)
 	// Set an initial value of 0 for the histogram so that it shows up in the metrics
-	uploadSizes.With(prometheus.Labels{"account": "testAccount", "org_id": "testOrg", "app": "testApp"})
+	uploadSizes.With(prometheus.Labels{"app": "testApp"})
 }


### PR DESCRIPTION
Do not include the org-id, account number in the upload size metrics.
Adjust the buckets.