### PR TITLE
RHCLOUD-40122 Add link to RDS dashboard in Export Service dashboard

### DIFF
--- a/dashboards/grafana-dashboard-insights-export-service-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-export-service-general.configmap.yaml
@@ -33,15 +33,6 @@ data:
               }
             },
             "type": "dashboard"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PDD8BE47D10408F45"
-            },
-            "enable": true,
-            "iconColor": "red",
-            "name": "crcs02ue1-prometheus"
           }
         ]
       },
@@ -49,7 +40,20 @@ data:
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
       "id": 886205,
-      "links": [],
+      "links": [
+        {
+          "asDropdown": false,
+          "icon": "dashboard",
+          "includeVars": false,
+          "keepTime": true,
+          "tags": [],
+          "targetBlank": true,
+          "title": "AWS RDS dashboard for Export Service",
+          "tooltip": "",
+          "type": "link",
+          "url": "https://grafana.app-sre.devshift.net/d/AWSRDSdbi/aws-rds?var-datasource=PD4288CE6A02EB473&var-region=default&var-dbinstanceidentifier=export-service-prod"
+        }
+      ],
       "liveNow": false,
       "panels": [
         {
@@ -805,9 +809,9 @@ data:
           {
             "allValue": "",
             "current": {
-              "selected": false,
-              "text": "crcs02ue1-prometheus",
-              "value": "crcs02ue1-prometheus"
+              "selected": true,
+              "text": "crcp01ue1-prometheus",
+              "value": "crcp01ue1-prometheus"
             },
             "hide": 0,
             "includeAll": false,
@@ -831,7 +835,7 @@ data:
       "timezone": "",
       "title": "ExportService Dashboard",
       "uid": "ir5blOCVk",
-      "version": 1,
+      "version": 3,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
## What?
[RHCLOUD-40122](https://issues.redhat.com/browse/RHCLOUD-40122)
This PR adds a link to the AWS RDS dashboard maintained by App SRE to the Export Service dashboard.

## Why?
This is better than adding the graphs about the DB into the Export Service dashboard directly because we won't have to maintain the graphs with the approach from this PR.

## How?
Describe how the change is implemented. Any noteable new libaries, APIs, or features.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
