### PR TITLE
[RHCLOUD-41106] bump Go and deps for vulns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,6 @@ FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
 USER root
 
 WORKDIR /workspace
-
-# The current ubi9 image does not include Go 1.24, so we specify it.
-# Adding "auto" will allow a newer version to be downloaded if specified in go.mod
-ARG GOTOOLCHAIN=go1.24.3+auto
-
 # Cache deps before copying source so that we do not need to re-download for every build
 COPY go.mod go.sum .
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/redhatinsights/export-service-go
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.24.4
 
 require (
 	github.com/RedHatInsights/event-schemas-go v1.0.6
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.2
 	github.com/confluentinc/confluent-kafka-go v1.8.2
 	github.com/fergusstrange/embedded-postgres v1.19.0
-	github.com/go-chi/chi/v5 v5.0.11
+	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-openapi/runtime v0.23.3
 	github.com/golang-migrate/migrate/v4 v4.18.3
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/chi/v5 v5.0.11 h1:BnpYbFZ3T3S1WMpD79r7R5ThWX40TaFB7L31Y8xqSwA=
 github.com/go-chi/chi/v5 v5.0.11/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=


### PR DESCRIPTION
## What?

- https://issues.redhat.com/browse/RHCLOUD-41106
- https://issues.redhat.com/browse/RHCLOUD-40848

## Why?
See first ticket.

## How?
Bump Go version and dependencies, see first ticket.

## Testing
Did you add any tests for the change?

## Anything Else?
Any other notes about the PR that would be useful for the reviewer. 

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
