### PR TITLE
RHCLOUD-46528: Add standardized internal API path /internal/export/v1

### DIFF
--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -99,23 +99,22 @@ func createPrivateServer(cfg *config.ExportConfig, internal exports.Internal) *h
 
 	router.Get("/", statusOK)
 
-	internalRoutes := func(r chi.Router) {
-		if !cfg.DisableServiceToServicePSKAuth {
-			r.Use(emiddleware.EnforcePSK)
-		} else {
-			log.Info("PSK auth disabled for service-to-service requests")
+	internalRoutes := func(basePath string) func(r chi.Router) {
+		return func(r chi.Router) {
+			r.Use(metrics.InternalUseTracker(basePath))
+			if !cfg.DisableServiceToServicePSKAuth {
+				r.Use(emiddleware.EnforcePSK)
+			} else {
+				log.Info("PSK auth disabled for service-to-service requests")
+			}
+			// add internal routes
+			r.Get("/ping", helloWorld) // Hello World endpoint
+			r.Route("/", internal.InternalRouter)
 		}
-		// add internal routes
-		r.Get("/ping", helloWorld) // Hello World endpoint
-		r.Route("/", internal.InternalRouter)
 	}
 
-	router.Route("/app/export/v1", internalRoutes)
-
-	if cfg.DisableServiceToServicePSKAuth {
-		log.Info("registering standardized internal API path /internal/export/v1")
-		router.Route("/internal/export/v1", internalRoutes)
-	}
+	router.Route("/app/export/v1", internalRoutes("/app/export/v1"))
+	router.Route("/internal/export/v1", internalRoutes("/internal/export/v1"))
 
 	return &http.Server{
 		Addr:    fmt.Sprintf(":%d", cfg.PrivatePort),

--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -99,7 +99,7 @@ func createPrivateServer(cfg *config.ExportConfig, internal exports.Internal) *h
 
 	router.Get("/", statusOK)
 
-	router.Route("/app/export/v1", func(r chi.Router) {
+	internalRoutes := func(r chi.Router) {
 		if !cfg.DisableServiceToServicePSKAuth {
 			r.Use(emiddleware.EnforcePSK)
 		} else {
@@ -108,7 +108,14 @@ func createPrivateServer(cfg *config.ExportConfig, internal exports.Internal) *h
 		// add internal routes
 		r.Get("/ping", helloWorld) // Hello World endpoint
 		r.Route("/", internal.InternalRouter)
-	})
+	}
+
+	router.Route("/app/export/v1", internalRoutes)
+
+	if cfg.DisableServiceToServicePSKAuth {
+		log.Info("registering standardized internal API path /internal/export/v1")
+		router.Route("/internal/export/v1", internalRoutes)
+	}
 
 	return &http.Server{
 		Addr:    fmt.Sprintf(":%d", cfg.PrivatePort),

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -52,7 +52,25 @@ func PrometheusMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+var internalAPIReqs = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "export_service_internal_api_requests_total",
+		Help: "How many internal API requests processed, partitioned by base path.",
+	},
+	[]string{"base_path"},
+)
+
+func InternalUseTracker(basePath string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			internalAPIReqs.WithLabelValues(basePath).Inc()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 func init() {
 	prometheus.MustRegister(httpReqs)
 	prometheus.MustRegister(httpDuration)
+	prometheus.MustRegister(internalAPIReqs)
 }


### PR DESCRIPTION
Let's merge after https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/181392 so we can test bumping that ref in hccs for stage post deployment tests.