### PR TITLE
Remove optional rbac dependency from ClowdApp

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -13,8 +13,6 @@ objects:
       envName: ${ENV_NAME}
       testing:
         iqePlugin: ${APP_NAME}
-      optionalDependencies:
-        - rbac
       deployments:
         - name: service
           minReplicas: ${{MIN_REPLICAS}}


### PR DESCRIPTION
## Summary
- Remove `optionalDependencies: [rbac]` from ClowdApp template
- RBAC service is not deployed on HCC clusters (hccp01ue1), causing ClowdApp to report missing dependencies and block deployment with 0 ready deployments
- Despite being declared as `optionalDependencies`, Clowder still treats it as a hard blocker

## Test plan
- [ ] Verify export-service deploys successfully on hccp01ue1 without rbac dependency
- [ ] Verify export-service continues to work on crcp01ue1 where rbac is present