### PR TITLE
Bump golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -23,4 +23,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.3.0
+          version: v2.12.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.64.5
+  rev: v2.12.2
   hooks:
     - id: golangci-lint


### PR DESCRIPTION
## Summary
- Bump golangci-lint from v2.3.0 to v2.12.2 in CI workflow — v2.3.0 was built with Go 1.24 which fails against our Go 1.25 target
- Bump pre-commit hook from v1.64.5 (v1 branch) to v2.12.2

## Test plan
- [ ] golangci-lint CI job passes on this PR