### PR TITLE
Fix DB migration path for hummingbird runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN GO111MODULE=on go build -ldflags "-w -s" -o export-service cmd/export-servic
 ############################
 FROM registry.access.redhat.com/hi/go:latest-fips
 
+WORKDIR /
+
 COPY --from=builder /workspace/export-service /usr/bin
 COPY --from=builder /workspace/db/migrations /db/migrations/
 COPY --from=builder /workspace/static/spec/openapi.json /var/tmp/openapi.json


### PR DESCRIPTION
## Summary
- Hummingbird runtime image (`hi/go:latest-fips`) sets `WORKDIR /go` by default
- DB migration code uses relative path `file://db/migrations`, which resolved to `/go/db/migrations` instead of `/db/migrations`
- Add explicit `WORKDIR /` in runtime stage to restore correct path resolution