### PR TITLE
Remove unused EXPORTS_PSKS parameter from clowdapp

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -253,8 +253,6 @@ parameters:
   - description: Suspend the cleaner CronJob
     name: CLEANER_SUSPEND
     value: "false"
-  - name: EXPORTS_PSKS
-    value: testing-a-psk
   - name: LOG_LEVEL
     value: INFO
   - name: EXPORT_ENABLE_APPS


### PR DESCRIPTION
## What?
Removed unused EXPORTS_PSKS parameter from the clowdapp. The environment variable EXPORTS_PSKS gets its data from a secret

## Why?
This is just cleaning unused values

## How?
It shouldnt change anything - as this parameter does not seem to be used in the clowdapp. 

## Testing
No

## Anything Else?
I didn't find any reference of `EXPORTS_PSKS` in app-interface. 
I'm leaving it up to the reviewers to determine if this makes sense or if this should be rejected/closed.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
