### PR TITLE
RHCLOUD-49551: remove hardcoded PSKs, add application-bound PSK auth

### DIFF
--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -102,10 +102,14 @@ func createPrivateServer(cfg *config.ExportConfig, internal exports.Internal) *h
 	internalRoutes := func(basePath string) func(r chi.Router) {
 		return func(r chi.Router) {
 			r.Use(metrics.InternalUseTracker(basePath))
-			if !cfg.DisableServiceToServicePSKAuth && len(cfg.PskMap) == 0 && len(cfg.Psks) > 0 {
-				r.Use(emiddleware.EnforcePSK)
-			} else if cfg.DisableServiceToServicePSKAuth {
+			if cfg.DisableServiceToServicePSKAuth {
 				log.Info("PSK auth disabled for service-to-service requests")
+			} else if len(cfg.PskMap) > 0 {
+				log.Info("using application-bound PSK auth")
+			} else if len(cfg.Psks) > 0 {
+				r.Use(emiddleware.EnforcePSK)
+			} else {
+				log.Warn("PSK auth enabled but no PSKs configured — internal API will reject all requests")
 			}
 			r.Get("/ping", helloWorld)
 			r.Route("/", internal.InternalRouter)

--- a/cmd/export-service/api_server.go
+++ b/cmd/export-service/api_server.go
@@ -102,13 +102,12 @@ func createPrivateServer(cfg *config.ExportConfig, internal exports.Internal) *h
 	internalRoutes := func(basePath string) func(r chi.Router) {
 		return func(r chi.Router) {
 			r.Use(metrics.InternalUseTracker(basePath))
-			if !cfg.DisableServiceToServicePSKAuth {
+			if !cfg.DisableServiceToServicePSKAuth && len(cfg.PskMap) == 0 && len(cfg.Psks) > 0 {
 				r.Use(emiddleware.EnforcePSK)
-			} else {
+			} else if cfg.DisableServiceToServicePSKAuth {
 				log.Info("PSK auth disabled for service-to-service requests")
 			}
-			// add internal routes
-			r.Get("/ping", helloWorld) // Hello World endpoint
+			r.Get("/ping", helloWorld)
 			r.Route("/", internal.InternalRouter)
 		}
 	}
@@ -233,11 +232,17 @@ func startApiServer(cfg *config.ExportConfig, log *zap.SugaredLogger) {
 	}
 	wsrv := createPublicServer(cfg, external)
 
+	var pskMiddleware func(http.Handler) http.Handler
+	if !cfg.DisableServiceToServicePSKAuth && len(cfg.PskMap) > 0 {
+		pskMiddleware = emiddleware.EnforceAppBoundPSK(cfg.PskMap)
+	}
+
 	internal := exports.Internal{
-		Cfg:        cfg,
-		Compressor: &storageHandler,
-		DB:         &models.ExportDB{DB: DB, Cfg: cfg},
-		Log:        log,
+		Cfg:           cfg,
+		Compressor:    &storageHandler,
+		DB:            &models.ExportDB{DB: DB, Cfg: cfg},
+		Log:           log,
+		PSKMiddleware: pskMiddleware,
 	}
 	psrv := createPrivateServer(cfg, internal)
 	msrv := createMetricsServer(cfg)

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -38,6 +39,7 @@ type ExportConfig struct {
 	OpenAPIPublicPath             string
 	DisableServiceToServicePSKAuth bool
 	Psks                          []string
+	PskMap                        map[string]string
 	ExportExpiryDays              int
 	ExportableApplications        map[string]map[string]bool
 	MaxPayloadSize                int
@@ -120,7 +122,8 @@ func Get() *ExportConfig {
 		options.SetDefault("DEBUG", false)
 		options.SetDefault("OPEN_API_FILE_PATH", "./static/spec/openapi.json")
 		options.SetDefault("OPEN_API_PRIVATE_PATH", "./static/spec/private.json")
-		options.SetDefault("PSKS", strings.Split(os.Getenv("EXPORTS_PSKS"), ","))
+		options.SetDefault("PSKS", []string{})
+		options.SetDefault("PSK_MAP", map[string]string{})
 		options.SetDefault("EXPORT_EXPIRY_DAYS", 7)
 		options.SetDefault("EXPORT_ENABLE_APPS", "{\"exampleApp\":[\"exampleResource\", \"anotherExampleResource\"]}")
 		options.SetDefault("MAX_PAYLOAD_SIZE", 500)
@@ -160,6 +163,8 @@ func Get() *ExportConfig {
 		kubenv := viper.New()
 		kubenv.AutomaticEnv()
 
+		psks, pskMap := parsePSKs(os.Getenv("EXPORTS_PSKS"))
+
 		config = &ExportConfig{
 			Hostname:                      kubenv.GetString("Hostname"),
 			PublicPort:                    options.GetInt("PUBLIC_PORT"),
@@ -173,7 +178,8 @@ func Get() *ExportConfig {
 			LogLevel:                      options.GetString("LOG_LEVEL"),
 			OpenAPIPublicPath:             options.GetString("OPEN_API_FILE_PATH"),
 			OpenAPIPrivatePath:            options.GetString("OPEN_API_PRIVATE_PATH"),
-			Psks:                          options.GetStringSlice("PSKS"),
+			Psks:                          psks,
+			PskMap:                        pskMap,
 			ExportExpiryDays:              options.GetInt("EXPORT_EXPIRY_DAYS"),
 			ExportableApplications:        convertExportableAppsFromConfigToInternal(options.GetStringMapStringSlice("EXPORT_ENABLE_APPS")),
 			MaxPayloadSize:                options.GetInt("MAX_PAYLOAD_SIZE"),
@@ -315,6 +321,32 @@ func buildBaseHttpUrl(tlsEnabled bool, hostname string, port int) string {
 	}
 
 	return fmt.Sprintf("%s://%s:%d", protocol, hostname, port)
+}
+
+// parsePSKs parses the EXPORTS_PSKS value into either a flat list or an
+// application-bound map. JSON objects (e.g. {"app":"psk"}) populate pskMap;
+// comma-separated values populate the flat psks slice.
+func parsePSKs(raw string) (psks []string, pskMap map[string]string) {
+	pskMap = make(map[string]string)
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, pskMap
+	}
+
+	if strings.HasPrefix(raw, "{") {
+		if err := json.Unmarshal([]byte(raw), &pskMap); err == nil && len(pskMap) > 0 {
+			return nil, pskMap
+		}
+	}
+
+	parts := strings.Split(raw, ",")
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			psks = append(psks, p)
+		}
+	}
+	return psks, make(map[string]string)
 }
 
 func convertExportableAppsFromConfigToInternal(config map[string][]string) map[string]map[string]bool {

--- a/config/config.go
+++ b/config/config.go
@@ -122,8 +122,7 @@ func Get() *ExportConfig {
 		options.SetDefault("DEBUG", false)
 		options.SetDefault("OPEN_API_FILE_PATH", "./static/spec/openapi.json")
 		options.SetDefault("OPEN_API_PRIVATE_PATH", "./static/spec/private.json")
-		options.SetDefault("PSKS", []string{})
-		options.SetDefault("PSK_MAP", map[string]string{})
+		// PSK values are parsed from EXPORTS_PSKS env var by parsePSKs()
 		options.SetDefault("EXPORT_EXPIRY_DAYS", 7)
 		options.SetDefault("EXPORT_ENABLE_APPS", "{\"exampleApp\":[\"exampleResource\", \"anotherExampleResource\"]}")
 		options.SetDefault("MAX_PAYLOAD_SIZE", 500)
@@ -334,7 +333,9 @@ func parsePSKs(raw string) (psks []string, pskMap map[string]string) {
 	}
 
 	if strings.HasPrefix(raw, "{") {
-		if err := json.Unmarshal([]byte(raw), &pskMap); err == nil && len(pskMap) > 0 {
+		if err := json.Unmarshal([]byte(raw), &pskMap); err != nil {
+			fmt.Printf("WARNING: EXPORTS_PSKS looks like JSON but failed to parse: %v — falling back to flat list\n", err)
+		} else if len(pskMap) > 0 {
 			return nil, pskMap
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestParsePSKs(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantPsks     []string
+		wantPskMap   map[string]string
+		wantFlatMode bool
+	}{
+		{
+			name:         "empty string",
+			input:        "",
+			wantPsks:     nil,
+			wantPskMap:   map[string]string{},
+			wantFlatMode: false,
+		},
+		{
+			name:         "single flat PSK",
+			input:        "my-secret-psk",
+			wantPsks:     []string{"my-secret-psk"},
+			wantFlatMode: true,
+		},
+		{
+			name:         "multiple flat PSKs",
+			input:        "psk1,psk2,psk3",
+			wantPsks:     []string{"psk1", "psk2", "psk3"},
+			wantFlatMode: true,
+		},
+		{
+			name:         "flat PSKs with whitespace",
+			input:        " psk1 , psk2 ",
+			wantPsks:     []string{"psk1", "psk2"},
+			wantFlatMode: true,
+		},
+		{
+			name:  "JSON app-bound PSKs",
+			input: `{"subscriptions":"psk-subs","urn:redhat:application:inventory":"psk-inv"}`,
+			wantPskMap: map[string]string{
+				"subscriptions":                    "psk-subs",
+				"urn:redhat:application:inventory": "psk-inv",
+			},
+			wantFlatMode: false,
+		},
+		{
+			name:         "invalid JSON falls back to flat",
+			input:        `{invalid-json`,
+			wantPsks:     []string{"{invalid-json"},
+			wantFlatMode: true,
+		},
+		{
+			name:         "empty JSON object falls back to flat",
+			input:        `{}`,
+			wantPsks:     []string{"{}"},
+			wantFlatMode: true,
+		},
+		{
+			name:         "trailing commas ignored",
+			input:        "psk1,,psk2,",
+			wantPsks:     []string{"psk1", "psk2"},
+			wantFlatMode: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			psks, pskMap := parsePSKs(tt.input)
+
+			if tt.wantFlatMode {
+				if len(pskMap) != 0 {
+					t.Errorf("expected empty pskMap in flat mode, got %v", pskMap)
+				}
+				if len(psks) != len(tt.wantPsks) {
+					t.Fatalf("expected %d psks, got %d: %v", len(tt.wantPsks), len(psks), psks)
+				}
+				for i, want := range tt.wantPsks {
+					if psks[i] != want {
+						t.Errorf("psks[%d] = %q, want %q", i, psks[i], want)
+					}
+				}
+			} else {
+				if psks != nil {
+					t.Errorf("expected nil psks in map mode, got %v", psks)
+				}
+				if len(pskMap) != len(tt.wantPskMap) {
+					t.Fatalf("expected %d pskMap entries, got %d: %v", len(tt.wantPskMap), len(pskMap), pskMap)
+				}
+				for k, want := range tt.wantPskMap {
+					got, ok := pskMap[k]
+					if !ok {
+						t.Errorf("pskMap missing key %q", k)
+					} else if got != want {
+						t.Errorf("pskMap[%q] = %q, want %q", k, got, want)
+					}
+				}
+			}
+		})
+	}
+}

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -170,16 +170,6 @@ objects:
       sessionAffinity: None
       type: ClusterIP
 
-  - apiVersion: v1
-    kind: Secret
-    metadata:
-      name: export-service-psks
-      labels:
-        app: export-service
-    data:
-      psk-list: "dGVzdGluZy1hLXBzayx0ZXN0aW5nLWEtcHNrLTI="
-    type: Opaque
-
 parameters:
   - name: APP_NAME
     description: Application common name
@@ -253,8 +243,6 @@ parameters:
   - description: Suspend the cleaner CronJob
     name: CLEANER_SUSPEND
     value: "false"
-  - name: EXPORTS_PSKS
-    value: testing-a-psk
   - name: LOG_LEVEL
     value: INFO
   - name: EXPORT_ENABLE_APPS

--- a/exports/internal.go
+++ b/exports/internal.go
@@ -23,10 +23,11 @@ import (
 
 // Internal contains the configuration and
 type Internal struct {
-	Cfg        *config.ExportConfig
-	Compressor s3.StorageHandler
-	DB         models.DBInterface
-	Log        *zap.SugaredLogger
+	Cfg           *config.ExportConfig
+	Compressor    s3.StorageHandler
+	DB            models.DBInterface
+	Log           *zap.SugaredLogger
+	PSKMiddleware func(http.Handler) http.Handler
 }
 
 // InternalRouter is a router for all of the internal routes which require exportuuid,
@@ -34,6 +35,9 @@ type Internal struct {
 func (i *Internal) InternalRouter(r chi.Router) {
 	r.Route("/{exportUUID}/{application}/{resourceUUID}", func(sub chi.Router) {
 		sub.Use(middleware.URLParamsCtx)
+		if i.PSKMiddleware != nil {
+			sub.Use(i.PSKMiddleware)
+		}
 		sub.Post("/upload", i.PostUpload)
 		sub.Post("/error", i.PostError)
 	})

--- a/middleware/psks.go
+++ b/middleware/psks.go
@@ -23,7 +23,8 @@ func SliceContainsString(slice []string, target string) bool {
 	return false
 }
 
-// EnforcePSK is a middleware that checks for a valid x-rh-exports-psk header.
+// EnforcePSK is a middleware that checks for a valid x-rh-exports-psk header
+// against a flat list of PSKs. Any valid PSK grants access regardless of application.
 func EnforcePSK(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		psk := r.Header["X-Rh-Exports-Psk"]
@@ -40,4 +41,39 @@ func EnforcePSK(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+// EnforceAppBoundPSK is a middleware that validates the x-rh-exports-psk header
+// against an application-specific PSK. It must run after URLParamsCtx so the
+// application name is available in the request context.
+func EnforceAppBoundPSK(pskMap map[string]string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			psk := r.Header["X-Rh-Exports-Psk"]
+
+			if len(psk) != 1 {
+				BadRequestError(w, "missing x-rh-exports-psk header")
+				return
+			}
+
+			params := GetURLParams(r.Context())
+			if params == nil {
+				JSONError(w, "unable to determine application context", http.StatusInternalServerError)
+				return
+			}
+
+			expectedPSK, ok := pskMap[params.Application]
+			if !ok {
+				JSONError(w, "no PSK configured for application", http.StatusForbidden)
+				return
+			}
+
+			if psk[0] != expectedPSK {
+				JSONError(w, "invalid x-rh-exports-psk header for application", http.StatusUnauthorized)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
 }

--- a/middleware/psks_test.go
+++ b/middleware/psks_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	// exportconfig from the config package
 	config "github.com/redhatinsights/export-service-go/config"
 	"github.com/redhatinsights/export-service-go/middleware"
 )
@@ -20,7 +19,6 @@ var validExportConfig = &config.ExportConfig{
 var _ = Describe("Handler", func() {
 	DescribeTable("Test EnforcePSK function",
 		func(useHeader, useMultipleHeaders bool, header string, expectedStatus int) {
-			// set the user's config to validExportConfig
 			middleware.Cfg = validExportConfig
 
 			req, err := http.NewRequest("GET", "/test", nil)
@@ -39,8 +37,6 @@ var _ = Describe("Handler", func() {
 
 			rr := httptest.NewRecorder()
 			applicationHandler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-				// The EnforcePsk function does nothing to the context here
-
 				handlerCalled = true
 			})
 
@@ -53,9 +49,6 @@ var _ = Describe("Handler", func() {
 			router.ServeHTTP(rr, req)
 
 			Expect(rr.Code).To(Equal(expectedStatus))
-
-			// Handler should not be called if an error is expected
-			// The middleware would pass a bad context
 			Expect(handlerCalled).To(Equal(expectedStatus == http.StatusOK))
 		},
 		Entry("Test with no header", false, false, nil, http.StatusBadRequest),
@@ -63,5 +56,49 @@ var _ = Describe("Handler", func() {
 		Entry("Test with nil header", true, false, nil, http.StatusUnauthorized),
 		Entry("Test with invalid header", true, false, "invalid", http.StatusUnauthorized),
 		Entry("Test with valid header", true, false, validExportConfig.Psks[0], http.StatusOK),
+	)
+
+	DescribeTable("Test EnforceAppBoundPSK function",
+		func(useHeader bool, header string, application string, expectedStatus int) {
+			pskMap := map[string]string{
+				"subscriptions":                        "subs-psk-secret",
+				"urn:redhat:application:inventory":     "inv-psk-secret",
+			}
+			appBoundMiddleware := middleware.EnforceAppBoundPSK(pskMap)
+
+			exportUUID := "550e8400-e29b-41d4-a716-446655440000"
+			resourceUUID := "660e8400-e29b-41d4-a716-446655440000"
+			url := "/" + exportUUID + "/" + application + "/" + resourceUUID + "/upload"
+			req, err := http.NewRequest("POST", url, nil)
+			Expect(err).To(BeNil())
+
+			if useHeader {
+				req.Header.Set("X-Rh-Exports-Psk", header)
+			}
+
+			handlerCalled := false
+
+			rr := httptest.NewRecorder()
+			applicationHandler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				handlerCalled = true
+			})
+
+			router := chi.NewRouter()
+			router.Route("/{exportUUID}/{application}/{resourceUUID}", func(sub chi.Router) {
+				sub.Use(middleware.URLParamsCtx)
+				sub.Use(appBoundMiddleware)
+				sub.Post("/upload", applicationHandler)
+			})
+
+			router.ServeHTTP(rr, req)
+
+			Expect(rr.Code).To(Equal(expectedStatus))
+			Expect(handlerCalled).To(Equal(expectedStatus == http.StatusOK))
+		},
+		Entry("Valid PSK for correct app", true, "subs-psk-secret", "subscriptions", http.StatusOK),
+		Entry("Valid PSK for wrong app", true, "subs-psk-secret", "urn:redhat:application:inventory", http.StatusUnauthorized),
+		Entry("No PSK configured for app", true, "subs-psk-secret", "unknown-app", http.StatusForbidden),
+		Entry("Missing header", false, "", "subscriptions", http.StatusBadRequest),
+		Entry("Invalid PSK", true, "wrong-psk", "subscriptions", http.StatusUnauthorized),
 	)
 })


### PR DESCRIPTION
## Summary
- Remove hardcoded `export-service-psks` Secret with publicly known test PSKs from ClowdApp template
- Remove vestigial `EXPORTS_PSKS` template parameter
- Add application-bound PSK support: JSON-formatted `EXPORTS_PSKS` maps app names to PSKs, validated per-request

## How it works

**Backward compatible.** Comma-separated `EXPORTS_PSKS` (flat list) still works as before. JSON object format enables app binding:

```json
{"subscriptions":"psk-for-subs","urn:redhat:application:inventory":"psk-for-inv"}
```

When app-bound, the middleware validates the PSK matches the application in the request URL path.

## App-interface MR
https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/199065